### PR TITLE
Project breadcrumbs

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Router, NavigationEnd, Event } from '@angular/router';
 import { Location } from '@angular/common';
+import { UrlService } from './url.service';
 
 declare let gtag:Function;
 
@@ -14,9 +15,13 @@ export class AppComponent {
   
   title = 'Sustaining Environmental Capitol Initiative';
 
-  constructor(public router: Router) {
+	currentUrl: string = null;
+  constructor(private urlService: UrlService, public router: Router) {
   	this.router.events.subscribe(event => {
 			if(event instanceof NavigationEnd) {
+				this.urlService.setPreviousUrl(this.currentUrl);
+				this.currentUrl = event.url;
+				this.urlService.setCurrentUrl(this.currentUrl);
 				gtag('config', 'UA-3978613-27', 
 					{ 'page_path': event.urlAfterRedirects }
 				);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { SearchNavComponent } from './search-nav/search-nav.component'
 import { LocalJsonService } from './local-json.service'
 import { SciencebaseService } from './sciencebase.service'
 import { SearchService } from './search.service';
+import { UrlService } from './url.service';
 import { CscComponent } from './csc/csc.component'
 import { ProjectResourceComponent } from './project-resource/project-resource.component'
 import { Ng2SmartTableModule } from 'ng2-smart-table';
@@ -58,7 +59,7 @@ import { TitleLinkComponent } from './title-link/title-link.component'
   entryComponents: [
     TitleLinkComponent
   ],
-  providers: [GoogleAnalyticsService, LocalJsonService, SciencebaseService, SearchService, {provide: LocationStrategy, useClass: HashLocationStrategy}],
+  providers: [GoogleAnalyticsService, LocalJsonService, SciencebaseService, SearchService, UrlService, {provide: LocationStrategy, useClass: HashLocationStrategy}],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -4,6 +4,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { environment } from '../../environments/environment';
 import { TitleLinkComponent } from '../title-link/title-link.component';
 import { Location } from '@angular/common';
+import { UrlService } from '../url.service';
 
 @Component({
   selector: 'app-csc',
@@ -88,7 +89,7 @@ export class CscComponent implements OnInit {
     // this.source.setSort([{ field: 'id', direction: 'asc' }]);
   };
 
-  constructor(private route: ActivatedRoute, private localJson: LocalJsonService, private router: Router, private location: Location, private aroute: ActivatedRoute) {
+  constructor(private route: ActivatedRoute, private localJson: LocalJsonService, private router: Router, private location: Location, private aroute: ActivatedRoute, private urlService: UrlService) {
   }
 
   showAllProjects() {
@@ -214,9 +215,12 @@ export class CscComponent implements OnInit {
       this.sbId = this.id;
     }
     
-    // Generate current URL for breadcrumb
-    this.url = "#" + this.router.url;
+    this.urlService.currentUrl$
+    .subscribe((current_url: string) => {
+      this.url = "#" + current_url;
+    });
     this.title = this.csc_ids[this.sbId];
+    this.urlService.setPreviousTitle(this.title);
     this.localJson.loadCscProjects(this.sbId).subscribe(data => {
       this.cscProjectsList = data;
         // tslint:disable-next-line:forin

--- a/src/app/project/project.component.html
+++ b/src/app/project/project.component.html
@@ -1,5 +1,14 @@
 <div class="project container-fluid">
   <div class="row" *ngIf="projectJson">
+    <div class="col-md-12">
+      <div class="breadcrumbs">
+        <a href="#">Project Explorer Home</a>
+        <span class="trail" *ngIf="previousUrl">&gt;</span>
+        <a *ngIf="previousUrl" [href]="previousUrl">{{ previousTitle }}</a>
+        <span class="trail">&gt;</span>
+        <a [href]="currentUrl">Current Project</a>
+      </div>
+    </div>
     <div class="col-md-8">
       <h1>{{ projectJson.title }}</h1>
 

--- a/src/app/project/project.component.scss
+++ b/src/app/project/project.component.scss
@@ -27,6 +27,27 @@
     }
   }
 
+  .breadcrumbs {
+    color: #666;
+    font-weight: 100;
+    font-size: 16px;
+    display: inline;
+  
+    .trail {
+      margin-left: 15px;
+      margin-top: 15px;
+      margin-bottom: 15px;
+    }
+  
+    a {
+      color: #666;
+      font-weight: 100;
+      margin-left: 15px;
+      margin-top: 15px;
+      margin-bottom: 15px;
+    }
+  }
+
   .affiliations {
     padding-bottom: 1rem;
   }

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -104,7 +104,6 @@ export class ProjectComponent implements OnInit {
       if (previous_url != null) {
         this.previousUrl = "#" + previous_url;
       }
-      console.log(this.previousUrl);
     });
     this.urlService.previousTitle$
     .subscribe((previous_title: string) => {

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -5,6 +5,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { NgbModal, ModalDismissReasons } from '@ng-bootstrap/ng-bootstrap';
 import { DomSanitizer, SafeResourceUrl, SafeUrl} from '@angular/platform-browser';
 import { environment } from '../../environments/environment';
+import { UrlService } from '../url.service';
 
 @Component({
   selector: 'app-project',
@@ -20,6 +21,9 @@ export class ProjectComponent implements OnInit {
   previewImage: any;
   modal_image: any;
   closeResult: string;
+  previousUrl: string = '';
+  currentUrl: string = '';
+  previousTitle: string = '';
   trustedDashboardUrl : SafeUrl;
   sbURL = environment.sbmainURL;
 
@@ -59,7 +63,7 @@ export class ProjectComponent implements OnInit {
     'State of the Science': 'science-tools;subtopic=State%20of%20the%20Science'
   }
 
-  constructor(private route: ActivatedRoute, private localJson: LocalJsonService, private router: Router, private sanitizer: DomSanitizer, private modalService: NgbModal) { }
+  constructor(private route: ActivatedRoute, private localJson: LocalJsonService, private router: Router, private sanitizer: DomSanitizer, private modalService: NgbModal, private urlService: UrlService) { }
 
   openImage(imageModal, image) {
     this.modal_image = image;
@@ -95,6 +99,21 @@ export class ProjectComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.urlService.previousUrl$
+    .subscribe((previous_url: string) => {
+      if (previous_url != null) {
+        this.previousUrl = "#" + previous_url;
+      }
+      console.log(this.previousUrl);
+    });
+    this.urlService.previousTitle$
+    .subscribe((previous_title: string) => {
+      this.previousTitle = previous_title;
+    });
+    this.urlService.currentUrl$
+    .subscribe((current_url: string) => {
+      this.currentUrl = "#" + current_url;
+    });
     this.sub = this.route.params.subscribe(params => {
       this.projectId = params['id'];
       this.cscId = params['csc'];

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -5,6 +5,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { environment } from '../../environments/environment';
 import { TitleLinkComponent } from '../title-link/title-link.component';
 import { Location } from '@angular/common';
+import { UrlService } from '../url.service';
 
 @Component({
   selector: 'app-topics',
@@ -85,7 +86,7 @@ export class TopicsComponent implements OnInit {
   dataLoading = true;
   subtopicsFilter:string[] = null;
 
-  constructor(private route: ActivatedRoute, private localJson: LocalJsonService, private searchService: SearchService, private router: Router, private location: Location, private aroute: ActivatedRoute) { }
+  constructor(private route: ActivatedRoute, private localJson: LocalJsonService, private searchService: SearchService, private router: Router, private location: Location, private aroute: ActivatedRoute, private urlService: UrlService) { }
 
   filterProjectsList(event:any = null) {
     this.filteredProjectsList = [];
@@ -211,7 +212,10 @@ export class TopicsComponent implements OnInit {
 
   ngOnInit() {
 
-    this.url = "#" + this.router.url;
+    this.urlService.currentUrl$
+    .subscribe((current_url: string) => {
+      this.url = "#" + current_url;
+    });
 
     this.sub = this.route.params.subscribe(params => {
       this.topic = params['topic'];
@@ -231,6 +235,7 @@ export class TopicsComponent implements OnInit {
         this.current_csc = params['csc'];
       }
       this.page_title = this.topic_names[this.topic]
+      this.urlService.setPreviousTitle(this.page_title);
     });
     this.searchService.getTopics().subscribe(topics => {
       var topics = topics;

--- a/src/app/url.service.spec.ts
+++ b/src/app/url.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UrlService } from './url.service';
+
+describe('UrlService', () => {
+  let service: UrlService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UrlService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/url.service.ts
+++ b/src/app/url.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+@Injectable()
+export class UrlService {
+  private previousUrl: BehaviorSubject<string> = new BehaviorSubject<string>(null);
+  private currentUrl: BehaviorSubject<string> = new BehaviorSubject<string>(null);
+  private previousTitle: BehaviorSubject<string> = new BehaviorSubject<string>(null);
+
+  public previousUrl$: Observable<string> = this.previousUrl.asObservable();
+  public currentUrl$: Observable<string> = this.currentUrl.asObservable();
+  public previousTitle$: Observable<string> = this.previousTitle.asObservable();
+  
+  setPreviousUrl(previousUrl: string) {
+      this.previousUrl.next(previousUrl);
+  }
+
+  setCurrentUrl(currentUrl: string) {
+    this.currentUrl.next(currentUrl);
+  }
+
+  setPreviousTitle(previousTitle: string) {
+    this.previousTitle.next(previousTitle);
+  }
+}
+


### PR DESCRIPTION
This PR provides the functionality required to generate breadcrumbs for the project page. There is no simple way to generate this breadcrumb path in Angular, but instead, it was suggested we create an Angular service that individual pages can subscribe to for updates, specifically about the previous URL, previous title, and current URL.

This does not currently have the same CSS as the CSS refresh that Carolyn and Bruce have been focused on to allow for that same styling to be applied once the service is committed to the feature branch.