### PR TITLE
Update to mapped area after higher resolution CASC map was added.

### DIFF
--- a/src/app/cscs/cscs.component.html
+++ b/src/app/cscs/cscs.component.html
@@ -12,15 +12,15 @@
       <h3>Search by region</h3>
       <img class="casc-map" src="assets/images/casc_regional_map.png" usemap="#casc-image" (load)="imageResized();" />
       <map name="casc-image">
-        <area target="" alt="Alaska" title="Alaska" href="#/casc/alaska" coords="-1,2,405,303" shape="rect">
-        <area target="" alt="Pacific Islands" title="Pacific Islands" href="#/casc/pacific-islands" coords="-1,308,395,610" shape="rect">
-        <area target="" alt="Northwest" title="Northwest" href="#/casc/northwest" coords="451,-1,455,61,426,127,420,165,644,219,652,152,625,149,610,111,604,80,592,54,597,20" shape="poly">
-        <area target="" alt="Southwest" title="Southwest" href="#/casc/southwest" coords="420,170,409,209,411,257,421,322,432,371,476,416,485,442,526,448,588,493,636,501,675,257,647,252,642,224" shape="poly">
-        <area target="" alt="North Central" title="North Central" href="#/casc/north-central" coords="604,15,599,51,613,78,612,105,618,119,629,145,657,149,645,241,673,246,666,345,937,360,926,286,897,215,897,137,886,54" shape="poly">
-        <area target="" alt="South Central" title="South Central" href="#/casc/south-central" coords="666,350,647,494,702,494,728,538,759,564,775,543,793,547,833,624,849,637,879,644,879,594,927,552,1047,559,1025,516,995,510,1000,465,939,464,929,365,795,360" shape="poly">
-        <area target="" alt="Midwest" title="Midwest" href="#/casc/midwest" coords="891,32,902,110,905,205,931,277,941,358,1018,358,1018,368,1038,364,1043,340,1061,319,1091,311,1114,282,1156,288,1178,256,1176,202,1132,205,1133,153,1116,116,1086,85,933,27" shape="poly">
-        <area target="" alt="Southeast" title="Southeast" href="#/casc/southeast" coords="938,367,943,461,998,461,1005,477,998,507,1031,511,1034,524,1116,527,1126,538,1150,524,1175,548,1201,607,1231,633,1251,591,1233,549,1397,543,1397,445,1231,439,1299,333,1105,355,1021,373" shape="poly">
-        <area target="" alt="Northeast" title="Northeast" href="#/casc/northeast" coords="1321,22,1312,84,1252,105,1237,152,1200,158,1200,178,1180,198,1183,245,1162,290,1117,286,1095,311,1057,327,1043,359,1293,325,1307,228,1361,176,1346,141,1383,87,1355,22" shape="poly">
+        <area target="" alt="Alaska" title="Alaska" href="#/casc/alaska" coords="-1,0,582,453" shape="rect">
+        <area target="" alt="Pacific Islands" title="Pacific Islands" href="#/casc/pacific-islands" coords="-1,468,607,934" shape="rect">
+        <area target="" alt="Northwest" title="Northwest" href="#/casc/northwest" coords="587,4,589,262,939,341,954,241,910,225,893,190,884,166,893,153,871,94,871,52,738,20" shape="poly">
+        <area target="" alt="Southwest" title="Southwest" href="#/casc/southwest" coords="609,269,593,326,613,468,633,564,672,593,707,645,705,667,766,676,919,748,934,741,980,385,939,378,934,345" shape="poly">
+        <area target="" alt="North Central" title="North Central" href="#/casc/north-central" coords="878,55,880,105,891,138,895,160,893,184,915,225,958,238,943,365,991,378,972,518,1352,538,1345,446,1326,398,1306,324,1304,223,1291,94" shape="poly">
+        <area target="" alt="South Central" title="South Central" href="#/casc/south-central" coords="969,522,943,730,967,737,974,719,1013,726,1055,772,1063,802,1103,837,1125,811,1151,813,1190,879,1208,929,1273,947,1299,855,1374,815,1511,837,1490,761,1439,757,1446,691,1363,691,1350,549" shape="poly">
+        <area target="" alt="Midwest" title="Midwest" href="#/casc/midwest" coords="1293,57,1310,212,1312,324,1345,415,1358,444,1363,536,1468,534,1472,549,1498,540,1516,503,1540,475,1590,459,1612,422,1680,437,1708,387,1704,300,1640,315,1658,271,1640,221,1614,181,1599,147,1468,101,1369,59" shape="poly">
+        <area target="" alt="Southeast" title="Southeast" href="#/casc/southeast" coords="1352,549,1367,667,1374,684,1452,687,1444,748,1496,752,1507,781,1562,781,1614,772,1627,789,1669,774,1702,805,1699,844,1771,936,1806,923,1813,827,2036,818,2036,652,1785,656,1876,549,1865,496,1671,525,1494,555" shape="poly">
+        <area target="" alt="Northeast" title="Northeast" href="#/casc/northeast" coords="1946,46,1914,46,1900,127,1815,173,1791,238,1739,249,1739,282,1712,308,1710,391,1680,444,1621,431,1588,466,1529,490,1507,536,1653,520,1872,483,1855,450,1892,391,2016,385,2012,321,1931,308,1981,262,1959,214,2005,140" shape="poly">
       </map>
     </div>
   </div>


### PR DESCRIPTION
This PR is simply to fix the mapped area for the CASC map on the home page. After we updated the image, it changed where the CASC areas are on the full-sized image. 