### PR TITLE
Advanced search filter fix for multiple copies of search filter items

### DIFF
--- a/src/app/search-nav/search-nav.component.ts
+++ b/src/app/search-nav/search-nav.component.ts
@@ -28,10 +28,10 @@ export class SearchNavComponent implements OnInit {
   totalResults: number;
   totalResultsSubscription: Subscription;
   multipleOrgs = true
-  resultOrgs
-  resultFY
-  resultTypes
-  resultStatus
+  resultOrgs:any = []
+  resultFY:any = []
+  resultTypes:any = []
+  resultStatus:any = []
   filteredOrg:any = []
   filteredFY:any = []
   filteredType:any = []
@@ -136,6 +136,9 @@ export class SearchNavComponent implements OnInit {
 
 
   onSubmit() {
+
+    // Wipe previous query on new search
+    this.searchService.wipeQuery()
 
     var queryString = '';
     var query = '?query=';


### PR DESCRIPTION
This PR fixes #87 where duplicates of the filter items were shown after clicking on the search button again. Needed to wipe the previous query before submitting the new query to be searched.

Closes #87 