### PR TITLE
Simplify CASC names in Topic component

### DIFF
--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -16,7 +16,7 @@
 						[id]="csc"
 						name="csc"
 					/>
-					<label [for]="csc">{{ csc }}</label>
+					<label [for]="csc">{{ csc.replace(" CASC", "") }}</label>
 				</div>
 			</div>
 			<div class="select-box">


### PR DESCRIPTION
This PR excludes the 'CASC' portion of any named CASC from the sidebar filter in Topic component.

Closes #62 