### PR TITLE
Fixes breadcrumb path when jumping from projects

### DIFF
--- a/src/app/breadcrumb/breadcrumb.component.html
+++ b/src/app/breadcrumb/breadcrumb.component.html
@@ -6,7 +6,8 @@
     Project Explorer Home</a
   >
   <span class="trail" *ngIf="previousUrl && previousUrl != '#/'">/</span>
-  <a *ngIf="previousUrl && previousUrl != '#/'" [href]="previousUrl">{{ previousTitle }}</a>
+  <a *ngIf="previousUrl && previousUrl != '#/' && !is_project()" [href]="previousUrl">{{ previousTitle }}</a>
+  <a *ngIf="previousUrl && is_project()" [href]="previousUrl">Referring Project</a>
   <span class="trail">/</span>
   <span class="leaf">{{ currentTitle }}</span>
 </div>

--- a/src/app/breadcrumb/breadcrumb.component.ts
+++ b/src/app/breadcrumb/breadcrumb.component.ts
@@ -16,6 +16,14 @@ export class BreadcrumbComponent implements OnInit {
 
   constructor(private urlService: UrlService) { }
 
+  is_project() {
+    if (this.previousUrl != null) {
+      if (this.previousUrl.includes('project')) {
+        return true;
+      }
+   }
+  }
+
   ngOnInit() {
     this.urlService.previousUrl$
     .subscribe((previous_url: string) => {


### PR DESCRIPTION
This PR adds a new breadcrumb for 'Referring Project' when jumping from a Project to Subproject, Subproject to Project, or Project to previous topic or CASC.

Closes #69 