### PR TITLE
Removes the Organization filter from the advanced search on the main screen

### DIFF
--- a/src/app/search-nav/search-nav.component.html
+++ b/src/app/search-nav/search-nav.component.html
@@ -43,17 +43,6 @@
   <div class="filters" *ngIf="totalResults > 0">
     <h4>Filters</h4>
     <div class="field">
-      <ng-select #orgs
-        [multiple]="true"
-        [items]="resultOrgs"
-        (change)="onOrgSourceChange($event.label)"
-        [(ngModel)]="filteredOrg"
-        [label]="Organizations"
-        (deselected)="onOrgSourceChange($event.label)"
-        placeholder="All Organizations">
-      </ng-select>
-    </div>
-    <div class="field">
       <ng-select #types
         [multiple]="true"
         [items]="resultTypes"


### PR DESCRIPTION
Closes #103 

Load the app.  Search for Moose.  There shouldn't be an Organization filter drop-down.