### PR TITLE
Adjusts color of sidebar to match a swath of the logo

### DIFF
--- a/src/app/project/project.component.scss
+++ b/src/app/project/project.component.scss
@@ -40,7 +40,7 @@
 
   .information-sidebar {
     margin: 2rem 0 2rem;
-    background-color: #DDF3FF;
+    background-color: #DAE9F6;
     padding: 1rem;
   }
 


### PR DESCRIPTION
Closes #123.

It's very subtle but just note that the color has been changed from the prior version.

I tested the color contrast in a 508 testing tool ([here](https://webaim.org/resources/contrastchecker/)) and the link color passes AA compliance at a ratio of 4.5-1.  