### PR TITLE
Includes preview images in media block

### DIFF
--- a/src/app/project/project.component.html
+++ b/src/app/project/project.component.html
@@ -209,7 +209,7 @@
           </li>
         </ul>
       </div>
-      <div *ngIf="projectJson.images && projectJson.images.length > 1">
+      <div *ngIf="(projectJson.images && projectJson.images.length > 1) || previewImage">
         <h2>Media</h2>
         <div class="media-cards">
           <div class="card" *ngFor="let image of projectJson.images">


### PR DESCRIPTION
Closes #124 

To test this, load this project URL:

http://dev.cascprojects.org/#/project/4f831626e4b0e84f6086809b/520d1ceee4b081fa6136d4c9

No media block is shown.  Then with this branch running, load:

http://localhost:4200/#/project/4f831626e4b0e84f6086809b/520d1ceee4b081fa6136d4c9

You should see a media image associated with this project.

Additionally, click through a bunch of other projects.  There should always be something.  (If not, there's nothing in SB).