### PR TITLE
Restores loading indicators when search is active

### DIFF
--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -47,6 +47,27 @@
 			</div>
 		</div>
 		<div class="col-md-10 results-table">
+			<div *ngIf="dataLoading">
+				<h4 class="loading">
+					<img
+						src="{{ approot }}assets/loading.gif"
+						class="loading"
+						alt="Loading Results"
+						title="Loading Results"
+					/>Loading {{ title }} ScienceBase projects&hellip;
+				</h4>
+			</div>
+			<div
+				class="no_data"
+				*ngIf="
+					filteredCscProjectsList.length == 0 && dataLoading == false
+				"
+			>
+				<h4 class="no_data">
+					No projects match all the search filters selected.
+				</h4>
+				<p>Remove one or more filters to see matching projects.</p>
+			</div>
 			<div
 				class="csc-projects"
 				*ngIf="!dataLoading && filteredCscProjectsList.length > 0"
@@ -57,32 +78,6 @@
 						[settings]="settings"
 						[source]="filteredCscProjectsList"
 					></ng2-smart-table>
-
-					<div *ngIf="dataLoading">
-						<h4 class="loading">Loading {{ title }} ScienceBase Projects.</h4>
-						<img
-							src="{{ approot }}assets/loading.gif"
-							class="loading"
-							alt="Loading Results"
-							title="Loading Results"
-						/>
-					</div>
-
-					<div
-						class="no_data"
-						*ngIf="filteredCscProjectsList.length == 0 && dataLoading == false"
-					>
-						<h4 class="no_data">
-							Use one or more filters above to select the topics, fiscal years,
-							or statises for the projects you wish to view.
-						</h4>
-						<button
-							class="btn btn-outline-secondary btn-small"
-							(click)="showAllProjects()"
-						>
-							See All Projects
-						</button>
-					</div>
 				</div>
 			</div>
 		</div>
@@ -119,10 +114,17 @@
 					<!--Principal Investigator-->
 					<div class="card-text">
 						<b>Principal Investigator(s): </b>
-						<ul *ngFor="let pi of project.contacts.principal_investigators">
+						<ul
+							*ngFor="
+								let pi of project.contacts
+									.principal_investigators
+							"
+						>
 							<li>
 								{{ pi.name }}
-								<em *ngIf="pi.organization">({{ pi.organization }})</em>
+								<em *ngIf="pi.organization"
+									>({{ pi.organization }})</em
+								>
 							</li>
 						</ul>
 					</div>
@@ -131,14 +133,18 @@
 					<div class="card-text">
 						<b>Topic(s): </b>
 
-						<span *ngIf="project?.topics"> {{ project.topics }} </span>
+						<span *ngIf="project?.topics">
+							{{ project.topics }}
+						</span>
 						<span *ngIf="!project.topics"> Unknown </span>
 					</div>
 
 					<!--Status-->
 					<div class="card-text">
 						<b>Status: </b>
-						<span *ngIf="project.status"> {{ project.status }} </span>
+						<span *ngIf="project.status">
+							{{ project.status }}
+						</span>
 						<span *ngIf="!project.status"> Unknown </span>
 					</div>
 				</div>

--- a/src/app/csc/csc.component.scss
+++ b/src/app/csc/csc.component.scss
@@ -6,3 +6,14 @@ label {
   position: relative;
   bottom: 1px;
 }
+
+.loading {
+  img {
+    display: inline-block;
+    height: 2rem;
+    padding-right: 1rem;
+    vertical-align: middle;
+    position: relative;
+    bottom: 0.2rem;
+  }
+}

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -3,10 +3,32 @@
     <search-nav></search-nav>
   </div>
   <div class="col-md-9 results">
-    <p *ngIf="results && results.length == 0">
+    <div class="loading" *ngIf="total_results == -1">
+      <h4 class="loading">
+        <img
+          src="{{ approot }}assets/loading.gif"
+          class="loading"
+          alt="Loading Results"
+          title="Loading Results"
+        />
+        Loading {{ title }} ScienceBase Projects.
+      </h4>
+    </div>
+    <div *ngIf="!noResult && results && results.length == 0 && total_results > -1">
       Enter search terms and filters using the controls, then click
       &ldquo;Search&rdquo; to get results.
-    </p>
+    </div>
+
+    <div *ngIf="noResult && total_results <= 0">
+      <p>Sorry, no matching items were found.  Try using different search terms.</p>
+    </div>
+
+    <div *ngIf="filteredResultsCount == -1 && total_results > 0">
+      <h4>Search Results with Filter</h4>
+      <p class="no_data">
+        No items exist that match the current filters.
+      </p>
+    </div>
     <div *ngIf="results.length > 0">
       <h4>
         Search Results
@@ -129,34 +151,6 @@
                 </div>
               </div>
             </div>
-          </div>
-        </div>
-
-        <div class="loading" *ngIf="total_results == -1">
-          <h4 class="loading">Loading {{ title }} ScienceBase Projects.</h4>
-          <img
-            src="{{ approot }}assets/loading.gif"
-            class="loading"
-            alt="Loading Results"
-            title="Loading Results"
-          />
-        </div>
-
-        <div class="no_search" *ngIf="total_results == 0">
-          <h4>Search Results</h4>
-          <p class="no_data">{{ noResult }}</p>
-        </div>
-
-        <div class="row">
-          <div
-            class="col-md-12 no_search"
-            *ngIf="filteredResultsCount == -1 && total_results > 0"
-          >
-            <h4>Search Results with Filter</h4>
-            <p class="no_data">
-              No projects exist that match the current filters. Please reset the
-              filters and refine your filters.
-            </p>
           </div>
         </div>
 

--- a/src/app/search/search.component.scss
+++ b/src/app/search/search.component.scss
@@ -13,6 +13,17 @@
   }
 }
 
+.loading {
+  img {
+    display: inline-block;
+    height: 2rem;
+    padding-right: 1rem;
+    vertical-align: middle;
+    position: relative;
+    bottom: 0.2rem;
+  }
+}
+
 .badges {
   color: white;
   margin-bottom: 1rem;

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -1,42 +1,47 @@
-import { Component, OnInit } from '@angular/core';
-import { SearchService } from '../search.service';
-import { Subscription } from 'rxjs';
-import { NgbModal, ModalDismissReasons } from '@ng-bootstrap/ng-bootstrap';
-import { DatePipe } from '@angular/common';
-import { environment } from '../../environments/environment';
+import { Component, OnInit } from "@angular/core";
+import { SearchService } from "../search.service";
+import { Subscription } from "rxjs";
+import { NgbModal, ModalDismissReasons } from "@ng-bootstrap/ng-bootstrap";
+import { DatePipe } from "@angular/common";
+import { environment } from "../../environments/environment";
 
 @Component({
-  selector: 'app-search',
-  templateUrl: './search.component.html',
-  styleUrls: ['./search.component.scss']
+  selector: "app-search",
+  templateUrl: "./search.component.html",
+  styleUrls: ["./search.component.scss"],
 })
-export class SearchComponent implements OnInit {    
-  results = []
-  total_results: number
-  filteredResultsCount: number
-  closeResult: string
-  noResult: string
-  filteredResultsSubscription: Subscription
-  filteredResultsCountSubscription: Subscription
-  totalResultsSubscription: Subscription 
-  nonProjectItem: any
-  loadingResults = false
-  sbURL = environment.sbmainURL
+export class SearchComponent implements OnInit {
+  results = [];
+  total_results: number;
+  filteredResultsCount: number;
+  closeResult: string;
+  noResult: boolean;
+  filteredResultsSubscription: Subscription;
+  filteredResultsCountSubscription: Subscription;
+  totalResultsSubscription: Subscription;
+  nonProjectItem: any;
+  sbURL = environment.sbmainURL;
 
-  constructor(private searchService: SearchService, private modalService: NgbModal) { }
+  constructor(
+    private searchService: SearchService,
+    private modalService: NgbModal
+  ) {}
 
   open(nonProject, item) {
     this.nonProjectItem = item;
-    this.modalService.open(nonProject, { size: 'lg' }).result.then((result) => {
-      this.closeResult = `Closed with: ${result}`;
-    }, (reason) => {
-      this.closeResult = `Dismissed ${this.getDismissReason(reason)}`;
-    });
+    this.modalService.open(nonProject, { size: "lg" }).result.then(
+      (result) => {
+        this.closeResult = `Closed with: ${result}`;
+      },
+      (reason) => {
+        this.closeResult = `Dismissed ${this.getDismissReason(reason)}`;
+      }
+    );
   }
 
   isProject(types) {
     for (var type in types) {
-      if (types[type] == 'Project') {
+      if (types[type] == "Project") {
         return true;
       }
     }
@@ -49,62 +54,67 @@ export class SearchComponent implements OnInit {
   */
   static niceDate(value) {
     try {
-      switch(value.split('-').length) {
+      switch (value.split("-").length) {
         case 2:
           /* the '-01' is a fix but the reason for why it's needed is unclear. */
-          return new DatePipe('en-US').transform(value + '-01', 'MM/yyyy');
+          return new DatePipe("en-US").transform(value + "-01", "MM/yyyy");
         case 3:
-          return new DatePipe('en-US').transform(value, 'MM/dd/yyyy');
-        case 1: default:
+          return new DatePipe("en-US").transform(value, "MM/dd/yyyy");
+        case 1:
+        default:
           return value;
       }
     } catch (error) {
-      console.error(`Could not parse value: ${value}`)
-      return value
+      console.error(`Could not parse value: ${value}`);
+      return value;
     }
   }
 
   ngOnInit() {
-    this.filteredResultsSubscription = this.searchService.filteredResults$.subscribe(filteredResults=>
-    {
-      this.results = filteredResults;      
-      for (let result of this.results) {
-        if (result.dates.start_date) {
-          result.dates.start_date = SearchComponent.niceDate(result.dates.start_date);
-        }
-        if (result.dates.end_date) {
-          result.dates.end_date = SearchComponent.niceDate(result.dates.end_date);
-        }
-        if (result.dates.publication_date) {
-          result.dates.publication_date = SearchComponent.niceDate(result.dates.publication_date);
+    this.filteredResultsSubscription = this.searchService.filteredResults$.subscribe(
+      (filteredResults) => {
+        this.results = filteredResults;
+        for (let result of this.results) {
+          if (result.dates.start_date) {
+            result.dates.start_date = SearchComponent.niceDate(
+              result.dates.start_date
+            );
+          }
+          if (result.dates.end_date) {
+            result.dates.end_date = SearchComponent.niceDate(
+              result.dates.end_date
+            );
+          }
+          if (result.dates.publication_date) {
+            result.dates.publication_date = SearchComponent.niceDate(
+              result.dates.publication_date
+            );
+          }
         }
       }
-    });
-    this.filteredResultsCountSubscription = this.searchService.filteredResultsCount$.subscribe(filteredResultsCount=>
-    {
-      this.filteredResultsCount = filteredResultsCount;
-    });
-    this.totalResultsSubscription = this.searchService.totalItem$.subscribe(totalItems=>
-    {     
-      // If no results are returned, totalItems returns a -1, then 0
-      // This code checks to see if a -1 has been returned, then it modifies the noResult message
-      if (this.total_results < 0) {        
-        this.noResult = "No results found. Enter (or modify) the search term(s)."
-      } else {
-        this.noResult = 'Use the search controls to create and filter your query.'
+    );
+    this.filteredResultsCountSubscription = this.searchService.filteredResultsCount$.subscribe(
+      (filteredResultsCount) => {
+        this.filteredResultsCount = filteredResultsCount;
       }
-      this.total_results = totalItems;      
-    });
-    
+    );
+    this.totalResultsSubscription = this.searchService.totalItem$.subscribe(
+      (totalItems) => {
+        // If no results are returned, totalItems returns a -1, then 0
+        // This code checks to see if a -1 has been returned, then it modifies the noResult message
+        this.noResult = this.total_results < 0;
+        this.total_results = totalItems;
+      }
+    );
   }
 
   private getDismissReason(reason: any): string {
     if (reason === ModalDismissReasons.ESC) {
-      return 'by pressing ESC';
+      return "by pressing ESC";
     } else if (reason === ModalDismissReasons.BACKDROP_CLICK) {
-      return 'by clicking on a backdrop';
+      return "by clicking on a backdrop";
     } else {
-      return  `with: ${reason}`;
+      return `with: ${reason}`;
     }
   }
 
@@ -112,5 +122,4 @@ export class SearchComponent implements OnInit {
     this.filteredResultsSubscription.unsubscribe();
     this.totalResultsSubscription.unsubscribe();
   }
-
 }

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -63,145 +63,133 @@
 			</div>
 		</div>
 
-		<div
-			class="col-md-10 results-table"
-			*ngIf="!dataLoading && filteredProjectsList.length > 0"
-		>
-			<div class="d-none d-lg-block">
-				<ng2-smart-table
-					class="table table-striped"
-					[settings]="settings"
-					[source]="filteredProjectsList"
-				></ng2-smart-table>
-
-				<div *ngIf="dataLoading">
-					<h4 class="loading">
-						Loading {{ title }} ScienceBase Projects.
-					</h4>
+		<div class="col-md-10 results-table">
+			<div *ngIf="dataLoading">
+				<h4 class="loading">
 					<img
 						src="{{ approot }}assets/loading.gif"
 						class="loading"
 						alt="Loading Results"
 						title="Loading Results"
-					/>
-				</div>
-
-				<div
-					class="no_data"
-					*ngIf="
-						filteredProjectsList.length == 0 && dataLoading == false
-					"
-				>
-					<h4 class="no_data">
-						Use one or more filters above to select the topics,
-						fiscal years, or statises for the projects you wish to
-						view.
-					</h4>
-					<button
-						class="btn btn-outline-secondary btn-small"
-						(click)="showAllProjects()"
-					>
-						See All Projects
-					</button>
-				</div>
+					/>Loading {{ title }} ScienceBase projects&hellip;
+				</h4>
 			</div>
 
-			<!-- ********************< Mobile Cards*****************************************************-->
 			<div
-				class="d-lg-none col-xs-10"
-				*ngIf="!dataLoading && filteredProjectsList.length > 0"
+				class="no_data"
+				*ngIf="filteredProjectsList.length == 0 && dataLoading == false"
 			>
-				<div class="card" *ngFor="let project of filteredProjectsList">
-					<!--Card content-->
-					<div class="card-block mobile">
-						<!--Title-->
-						<h4 class="card-title">
-							<a
-								[routerLink]="[
-									'/project/',
-									project.csc['id'],
-									project.id
-								]"
-							>
-								{{ project["title"] }}
-							</a>
-							<ul *ngIf="project.children?.length > 0">
-								<li
-									*ngFor="
-										let childProject of project.children
-									"
-								>
-									<span *ngIf="project.types == 'Project'">
-										<a
-											[routerLink]="[
-												'/project/',
-												project.csc['id'],
-												project.id
-											]"
-										>
-											{{ project["title"] }}
-										</a>
-									</span>
-									<span *ngIf="project.types != 'Project'">
-										<a
-											[routerLink]="[
-												'/component/',
-												project.id
-											]"
-										>
-											{{ project["title"] }}
-										</a>
-									</span>
-								</li>
-							</ul>
-						</h4>
-						<!--Project Year-->
-						<div class="card-text">
-							<b>Funding Year: </b>
-							<span *ngIf="project['fiscal_year']">
-								{{ project.fiscal_year }}
-							</span>
-							<span *ngIf="!project.fiscal_year"> N/A </span>
-						</div>
-
-						<!--CSC-->
-						<div class="card-text">
-							<b>CASC: </b>
-							<span> {{ project.csc.name }} </span>
-						</div>
-
-						<!--Subtopic(s)-->
-						<div class="card-text">
-							<b>Subtopic(s):</b>
-
-							<ul *ngFor="let st of project.subtopics">
-								<li *ngIf="isOnTopic(st)">
-									{{ st }}
-								</li>
-							</ul>
-
-							<span *ngIf="!project.subtopics"> N/A </span>
-						</div>
-
-						<!--Status-->
-						<div class="card-text">
-							<b>Status: </b>
-							<span *ngIf="project.status">
-								<span>{{ project.status }}</span>
-							</span>
-							<span *ngIf="!project.status">
-								<span>N/A</span>
-							</span>
-						</div>
-					</div>
-					<!--/.Card content-->
-				</div>
-				<br />
-				<br />
+				<h4 class="no_data">
+					No projects match all the search filters selected.
+				</h4>
+				<p>Remove one or more filters to see matching projects.</p>
 			</div>
 
-			<br />
-			<br />
+			<div *ngIf="!dataLoading && filteredProjectsList.length > 0">
+				<div class="d-none d-lg-block">
+					<ng2-smart-table
+						class="table table-striped"
+						[settings]="settings"
+						[source]="filteredProjectsList"
+					></ng2-smart-table>
+				</div>
+
+				<!-- Mobile -->
+				<div class="d-lg-none col-xs-10">
+					<div
+						class="card"
+						*ngFor="let project of filteredProjectsList"
+					>
+						<!--Card content-->
+						<div class="card-block mobile">
+							<!--Title-->
+							<h4 class="card-title">
+								<a
+									[routerLink]="[
+										'/project/',
+										project.csc['id'],
+										project.id
+									]"
+								>
+									{{ project["title"] }}
+								</a>
+								<ul *ngIf="project.children?.length > 0">
+									<li
+										*ngFor="
+											let childProject of project.children
+										"
+									>
+										<span
+											*ngIf="project.types == 'Project'"
+										>
+											<a
+												[routerLink]="[
+													'/project/',
+													project.csc['id'],
+													project.id
+												]"
+											>
+												{{ project["title"] }}
+											</a>
+										</span>
+										<span
+											*ngIf="project.types != 'Project'"
+										>
+											<a
+												[routerLink]="[
+													'/component/',
+													project.id
+												]"
+											>
+												{{ project["title"] }}
+											</a>
+										</span>
+									</li>
+								</ul>
+							</h4>
+							<!--Project Year-->
+							<div class="card-text">
+								<b>Funding Year: </b>
+								<span *ngIf="project['fiscal_year']">
+									{{ project.fiscal_year }}
+								</span>
+								<span *ngIf="!project.fiscal_year"> N/A </span>
+							</div>
+
+							<!--CSC-->
+							<div class="card-text">
+								<b>CASC: </b>
+								<span> {{ project.csc.name }} </span>
+							</div>
+
+							<!--Subtopic(s)-->
+							<div class="card-text">
+								<b>Subtopic(s):</b>
+
+								<ul *ngFor="let st of project.subtopics">
+									<li *ngIf="isOnTopic(st)">
+										{{ st }}
+									</li>
+								</ul>
+
+								<span *ngIf="!project.subtopics"> N/A </span>
+							</div>
+
+							<!--Status-->
+							<div class="card-text">
+								<b>Status: </b>
+								<span *ngIf="project.status">
+									<span>{{ project.status }}</span>
+								</span>
+								<span *ngIf="!project.status">
+									<span>N/A</span>
+								</span>
+							</div>
+						</div>
+						<!--/.Card content-->
+					</div>
+				</div>
+			</div>
 			<!--/.Card-->
 		</div>
 	</div>

--- a/src/app/topics/topics.component.scss
+++ b/src/app/topics/topics.component.scss
@@ -6,3 +6,14 @@ label {
   position: relative;
   bottom: 1px;
 }
+
+.loading {
+  img {
+    display: inline-block;
+    height: 2rem;
+    padding-right: 1rem;
+    vertical-align: middle;
+    position: relative;
+    bottom: 0.2rem;
+  }
+}


### PR DESCRIPTION
Closes #119, closes #133

To test:

 - Load the app, click on a Topic, and observe that there's a loading indicator.  On this same screen, keep selecting filters until there's no results: you should see a note to the user saying please pick fewer filters.
 - Now do the same for searching by CASC.  Load the app, click on a CASC region, and observe that there's a loading indicator.  On this same screen, keep selecting filters until there's no results: you should see a note to the user saying please pick fewer filters.

Next test advanced search:

- Load the app, search for Moose.  You should see a loading indicator while the request loads.
- Search for Cows.  You should see a note with no results after loading is done.  Click the Reset Query and you should see the default note "Enter search terms and filters...".

