### PR TITLE
Add "Other Product" badge for untagged items; remove Summary if there isn't one

### DIFF
--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -14,20 +14,22 @@
         Loading {{ title }} ScienceBase Projects.
       </h4>
     </div>
-    <div *ngIf="!noResult && results && results.length == 0 && total_results > -1">
+    <div
+      *ngIf="!noResult && results && results.length == 0 && total_results > -1"
+    >
       Enter search terms and filters using the controls, then click
       &ldquo;Search&rdquo; to get results.
     </div>
 
     <div *ngIf="noResult && total_results <= 0">
-      <p>Sorry, no matching items were found.  Try using different search terms.</p>
+      <p>
+        Sorry, no matching items were found. Try using different search terms.
+      </p>
     </div>
 
     <div *ngIf="filteredResultsCount == -1 && total_results > 0">
       <h4>Search Results with Filter</h4>
-      <p class="no_data">
-        No items exist that match the current filters.
-      </p>
+      <p class="no_data">No items exist that match the current filters.</p>
     </div>
     <div *ngIf="results.length > 0">
       <h4>
@@ -76,7 +78,9 @@
                 </div>
                 <div
                   *ngIf="
-                    result.types?.length > 0 && result.types == 'Other Product'
+                    (result.types?.length > 0 &&
+                      result.types == 'Other Product') ||
+                    result.types == null
                   "
                 >
                   <span class="badge badge-pill badge-other">
@@ -139,6 +143,7 @@
               </ul>
 
               <a
+                *ngIf="result.summary"
                 class="summary_link"
                 (click)="result.isCollapsed = !result.isCollapsed"
                 [attr.aria-expanded]="!result.isCollapsed"

--- a/src/app/search/search.component.scss
+++ b/src/app/search/search.component.scss
@@ -43,8 +43,8 @@
     background-color: #b24142;
   }
 
-  .badge-other-product {
-    background-color: #5478bf;
+  .badge-other {
+    background-color: #888;
   }
 }
 


### PR DESCRIPTION
Testing:

- Search for Moose
- Observe the product titled "Climate change, the Boreal Forest, and Moose: Project Summary" has an "Other Product" badge.
- Also observe that this item doesn't show the "Summary" link because there's no summary attached to that item.