### PR TITLE
Ensures that subtopics are not null before attempting to create the table showing the subtopics in the Topics page.

### DIFF
--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -423,28 +423,29 @@ export class TopicsComponent implements OnInit {
 
           // cscs and year
           for (var project in this.filteredProjectsList) {
-            this.projectsList[project].csc_name = this.projectsList[
-              project
-            ].csc["name"];
+            this.projectsList[project].csc_name =
+              this.projectsList[project].csc["name"];
 
             // subtopics
             this.projectsList[project].subtopics_formatted = "<ul>";
-            for (var st of this.projectsList[project].subtopics) {
-              if (
-                this.isOnTopic(st) &&
-                this.projectsList[project].subtopics_formatted.indexOf(st) < 0
-              ) {
-                this.projectsList[project].subtopics_formatted +=
-                  "<li>" + st + "</li>";
+            if (this.projectsList[project].subtopics != null) {
+              for (var st of this.projectsList[project].subtopics) {
+                if (
+                  this.isOnTopic(st) &&
+                  this.projectsList[project].subtopics_formatted.indexOf(st) < 0
+                ) {
+                  this.projectsList[project].subtopics_formatted +=
+                    "<li>" + st + "</li>";
+                }
               }
+              this.projectsList[project].subtopics_formatted += "</ul>";
             }
-            this.projectsList[project].subtopics_formatted += "</ul>";
-
             // status
             if (!this.projectsList[project].status) {
               this.projectsList[project].status = "N/A";
             }
           } //end for project
+          console.log(this.projectsList);
         }
 
         this.current_type = "Project";

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -427,8 +427,9 @@ export class TopicsComponent implements OnInit {
               this.projectsList[project].csc["name"];
 
             // subtopics
-            this.projectsList[project].subtopics_formatted = "<ul>";
+            this.projectsList[project].subtopics_formatted = "";
             if (this.projectsList[project].subtopics != null) {
+              this.projectsList[project].subtopics_formatted = "<ul>";
               for (var st of this.projectsList[project].subtopics) {
                 if (
                   this.isOnTopic(st) &&
@@ -445,7 +446,6 @@ export class TopicsComponent implements OnInit {
               this.projectsList[project].status = "N/A";
             }
           } //end for project
-          console.log(this.projectsList);
         }
 
         this.current_type = "Project";


### PR DESCRIPTION
This PR makes sure that the subtopics are set as null before attempting to iterate through them. This was discovered due to the API marking many of the subtopics and topics as null resulting in the website breaking.

To test:

Go to https://cascprojects.org/#/topics/water-coasts-ice and note that there is only a single item listed which is not a project.

On this branch locally, go to: http://localhost:4200/#/topics/water-coasts-ice and note that all of the items are listed even if the subtopics are all missing. 

This is likely a temporary need as it appears something may be broken on the API.