### PR TITLE
Adds alt text to logos in footer for accessibility

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -16,36 +16,45 @@
     <div class="logo-block container-fluid footer-container">
       <div class="row logos d-flex flex-wrap align-items-center">
         <div class="col">
-          <img src="assets/images/usgs-200.png" />
+          <img src="assets/images/usgs-200.png" alt="USGS logo" />
         </div>
         <div class="col">
-          <img src="assets/images/akcasc-200.png" />
+          <img src="assets/images/akcasc-200.png" alt="Alaska CASC logo" />
         </div>
         <div class="col">
-          <img src="assets/images/mwcasc-200.png" />
+          <img src="assets/images/mwcasc-200.png" alt="Midwest CASC logo" />
         </div>
         <div class="col">
-          <img src="assets/images/nccasc-200.png" />
+          <img
+            src="assets/images/nccasc-200.png"
+            alt="North Central CASC logo"
+          />
         </div>
         <div class="col">
-          <img src="assets/images/necasc-200.png" />
+          <img src="assets/images/necasc-200.png" alt="Northeast CASC logo" />
         </div>
       </div>
       <div class="row logos d-flex flex-wrap align-items-center">
         <div class="col">
-          <img src="assets/images/nwcasc-200.png" />
+          <img src="assets/images/nwcasc-200.png" alt="Northwest CASC logo" />
         </div>
         <div class="col">
-          <img src="assets/images/picasc-200.png" />
+          <img
+            src="assets/images/picasc-200.png"
+            alt="Pacific Islands CASC logo"
+          />
         </div>
         <div class="col">
-          <img src="assets/images/sscasc-200.png" />
+          <img
+            src="assets/images/sscasc-200.png"
+            alt="South Central CASC logo"
+          />
         </div>
         <div class="col">
-          <img src="assets/images/secasc-200.png" />
+          <img src="assets/images/secasc-200.png" alt="Southeast CASC logo" />
         </div>
         <div class="col">
-          <img src="assets/images/swcasc-200.png" />
+          <img src="assets/images/swcasc-200.png" alt="Southwest CASC logo" />
         </div>
       </div>
     </div>
@@ -57,10 +66,16 @@
       >
       <a href="mailto:casc@usgs.gov">Contact Us</a>
       <a href="https://twitter.com/usgs_climate?ref_src=twsrc%5Etfw"
-        ><img class="social-media-icon" src="assets/images/twitter.png"
+        ><img
+          class="social-media-icon"
+          src="assets/images/twitter.png"
+          alt="Twitter"
       /></a>
       <a href="https://www.instagram.com/usgs_climate/"
-        ><img class="social-media-icon" src="assets/images/instagram.png"
+        ><img
+          class="social-media-icon"
+          src="assets/images/instagram.png"
+          alt="Instagram"
       /></a>
     </div>
   </div>


### PR DESCRIPTION
This PR adds alt text to the images that are in the footer: all of the CASC logos, USGS logo, plus the Twitter and Instagram logos. This was done for accessibility improvements to the website.

Closes #157 