### PR TITLE
Updates CASC and topic project tables to have an arrow indicating sort direction on the Fiscal Year column by default

### DIFF
--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -57,6 +57,9 @@ export class CscComponent implements OnInit {
       fiscal_year: {
         title: "Year",
         width: "6%",
+        sort: true,
+        sortDirection: "desc",
+        defaultSortDirection: "desc",
       },
       title: {
         title: "Title",

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -39,6 +39,9 @@ export class TopicsComponent implements OnInit {
       fiscal_year: {
         title: "Year",
         width: "6%",
+        sort: true,
+        sortDirection: "desc",
+        defaultSortDirection: "desc",
       },
       title: {
         title: "Title",


### PR DESCRIPTION
This PR adds an arrow indicating sort direction on first page load for both the topics and CASC pages:

http://localhost:4200/#/casc/alaska
http://localhost:4200/#/topics/landscapes;type=Project

Closes #172 