### PR TITLE
Adds the ability to see how many projects are returned via CASC or topic selection

### DIFF
--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -70,6 +70,10 @@
         class="csc-projects"
         *ngIf="!dataLoading && filteredCscProjectsList.length > 0"
       >
+        <p>
+          <strong>Total projects:</strong>
+          {{ getFilteredProjectsCount() }}
+        </p>
         <div class="d-none d-lg-block">
           <ng2-smart-table
             class="table table-striped"

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -236,6 +236,10 @@ export class CscComponent implements OnInit {
     this.sortList();
   }
 
+  getFilteredProjectsCount() {
+    return this.filteredCscProjectsList.length;
+  }
+
   //TODO: put this code in a utility function/service
   updateUrl() {
     let params: any = {};

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -86,6 +86,10 @@
       </div>
 
       <div *ngIf="!dataLoading && filteredProjectsList.length > 0">
+        <p>
+          <strong>Total projects:</strong>
+          {{ getFilteredProjectsCount() }}
+        </p>
         <div class="d-none d-lg-block">
           <ng2-smart-table
             class="table table-striped"
@@ -111,7 +115,7 @@
                         [routerLink]="[
                           '/project/',
                           project.csc['id'],
-                          project.id,
+                          project.id
                         ]"
                       >
                         {{ project["title"] }}

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -268,6 +268,10 @@ export class TopicsComponent implements OnInit {
     this.sortList();
   }
 
+  getFilteredProjectsCount() {
+    return this.filteredProjectsList.length;
+  }
+
   showAllProjects() {
     this.filteredProjectsList = this.projectsList;
     this.current_subtopic = [];


### PR DESCRIPTION
This PR adds a small paragraph to the top of the table of projects in both the CASC and topic selection pages to indicate the number of projects currently displayed in the tables. This updates dynamically as you filter the results based on choices in the left hand side filter checkboxes.

Closes #167 