### PR TITLE
Adds the ability to see how many projects are returned via CASC or topic selection

### DIFF
--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -65,6 +65,10 @@
         class="csc-projects"
         *ngIf="!dataLoading && filteredCscProjectsList.length > 0"
       >
+        <p>
+          <strong>Total projects:</strong>
+          {{ getFilteredProjectsCount() }}
+        </p>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -65,10 +65,7 @@
         class="csc-projects"
         *ngIf="!dataLoading && filteredCscProjectsList.length > 0"
       >
-        <p>
-          <strong>Total projects:</strong>
-          {{ getFilteredProjectsCount() }}
-        </p>
+        <p>Showing ({{ getFilteredProjectsCount() }}) matching projects.</p>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -231,6 +231,10 @@ export class CscComponent implements OnInit {
     this.location.replaceState(url);
   }
 
+  getFilteredProjectsCount() {
+    return this.filteredCscProjectsList.length;
+  }
+
   ngOnInit() {
     this.sub = this.route.params.subscribe((params) => {
       this.id = params["id"];

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -90,10 +90,7 @@
       </div>
 
       <div *ngIf="!dataLoading && filteredProjectsList.length > 0">
-        <p>
-          <strong>Total projects:</strong>
-          {{ getFilteredProjectsCount() }}
-        </p>
+        <p>Showing ({{ getFilteredProjectsCount() }}) matching projects.</p>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -90,6 +90,10 @@
       </div>
 
       <div *ngIf="!dataLoading && filteredProjectsList.length > 0">
+        <p>
+          <strong>Total projects:</strong>
+          {{ getFilteredProjectsCount() }}
+        </p>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -302,6 +302,10 @@ export class TopicsComponent implements OnInit {
     this.location.replaceState(url);
   }
 
+  getFilteredProjectsCount() {
+    return this.filteredProjectsList.length;
+  }
+
   ngOnInit() {
     this.sub = this.route.params.subscribe((params) => {
       this.topic = params["topic"];


### PR DESCRIPTION
This PR adds a small paragraph to the top of the table of projects in both the CASC and topic selection pages to indicate the number of projects currently displayed in the tables. This updates dynamically as you filter the results based on choices in the left hand side filter checkboxes.

Closes https://github.com/ua-snap/nccwsc-projects/issues/167