### PR TITLE
Adds search bar to topics and CASC pages to allow for you to provide a search term to narrow the table's results

### DIFF
--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -65,6 +65,10 @@
         class="csc-projects"
         *ngIf="!dataLoading && filteredCscProjectsList.length > 0"
       >
+        <p>
+          <strong>Total projects:</strong>
+          {{ getFilteredProjectsCount() }}
+        </p>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -52,10 +52,7 @@
           />Loading {{ title }} ScienceBase projects&hellip;
         </h4>
       </div>
-      <div
-        class="no_data"
-        *ngIf="filteredCscProjectsList.length === 0 && dataLoading === false"
-      >
+      <div class="no_data" *ngIf="dataSource.data.length === 0 && !dataLoading">
         <h4 class="no_data">
           No projects match all the search filters selected.
         </h4>
@@ -63,9 +60,25 @@
       </div>
       <div
         class="csc-projects"
-        *ngIf="!dataLoading && filteredCscProjectsList.length > 0"
+        *ngIf="!dataLoading && dataSource.data.length > 0"
       >
         <p>Showing ({{ getFilteredProjectsCount() }}) matching projects.</p>
+        <div class="search-bar-div">
+          <div class="input-group mb-3 search-bar-wrapper">
+            <input
+              class="form-control search-bar"
+              type="text"
+              placeholder="Search by term"
+              [(ngModel)]="searchTerm"
+              (input)="applyFilter()"
+            />
+            <div class="input-group-append">
+              <span class="input-group-text">
+                <fa-icon [icon]="faSearch"></fa-icon>
+              </span>
+            </div>
+          </div>
+        </div>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -42,25 +42,26 @@
       </div>
     </div>
     <div class="col-md-10 results-table">
-      <!-- These sit outside of the divs because we want the search bar to still 
-           appear when we have no results shown so that we can remove the text in
-           the search bar to update the results.
-      -->
-      <p
-        *ngIf="!dataLoading && dataSource.filteredData.length > 0"
-        class="inline"
-      >
-        Showing ({{ dataSource.filteredData.length }}) matching projects.
-      </p>
-      <div *ngIf="!dataLoading" class="search-bar-div inline">
-        <div class="input-group mb-3 search-bar-wrapper">
-          <input
-            class="form-control search-bar"
-            type="text"
-            placeholder="Filter by term"
-            [(ngModel)]="searchTerm"
-            (input)="applyFilter()"
-          />
+      <!-- These need to still appear when we have no results shown so that we can remove the text in the search bar to update the results. -->
+
+      <div class="row pb-3">
+        <div class="col-8">
+          <p *ngIf="!dataLoading && dataSource.filteredData.length > 0">
+            Showing {{ dataSource.filteredData.length }} matching projects.
+          </p>
+        </div>
+        <div class="col-4">
+          <div *ngIf="!dataLoading" class="search-bar-div inline">
+            <div class="search-bar-wrapper">
+              <input
+                class="form-control search-bar"
+                type="text"
+                placeholder="Filter by term"
+                [(ngModel)]="searchTerm"
+                (input)="applyFilter()"
+              />
+            </div>
+          </div>
         </div>
       </div>
       <div *ngIf="dataLoading">

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -52,7 +52,7 @@
           />Loading {{ title }} ScienceBase projects&hellip;
         </h4>
       </div>
-      <div class="no_data" *ngIf="dataSource.data.length === 0 && !dataLoading">
+      <div class="no_data" *ngIf="!dataLoading && dataSource.data.length === 0">
         <h4 class="no_data">
           No projects match all the search filters selected.
         </h4>

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -42,6 +42,27 @@
       </div>
     </div>
     <div class="col-md-10 results-table">
+      <!-- These sit outside of the divs because we want the search bar to still 
+           appear when we have no results shown so that we can remove the text in
+           the search bar to update the results.
+      -->
+      <p
+        *ngIf="!dataLoading && dataSource.filteredData.length > 0"
+        class="inline"
+      >
+        Showing ({{ dataSource.filteredData.length }}) matching projects.
+      </p>
+      <div *ngIf="!dataLoading" class="search-bar-div inline">
+        <div class="input-group mb-3 search-bar-wrapper">
+          <input
+            class="form-control search-bar"
+            type="text"
+            placeholder="Filter by term"
+            [(ngModel)]="searchTerm"
+            (input)="applyFilter()"
+          />
+        </div>
+      </div>
       <div *ngIf="dataLoading">
         <h4 class="loading">
           <img
@@ -52,7 +73,10 @@
           />Loading {{ title }} ScienceBase projects&hellip;
         </h4>
       </div>
-      <div class="no_data" *ngIf="!dataLoading && dataSource.data.length === 0">
+      <div
+        class="no_data"
+        *ngIf="!dataLoading && dataSource.filteredData.length === 0"
+      >
         <h4 class="no_data">
           No projects match all the search filters selected.
         </h4>
@@ -60,25 +84,8 @@
       </div>
       <div
         class="csc-projects"
-        *ngIf="!dataLoading && dataSource.data.length > 0"
+        *ngIf="!dataLoading && dataSource.filteredData.length > 0"
       >
-        <p>Showing ({{ getFilteredProjectsCount() }}) matching projects.</p>
-        <div class="search-bar-div">
-          <div class="input-group mb-3 search-bar-wrapper">
-            <input
-              class="form-control search-bar"
-              type="text"
-              placeholder="Search by term"
-              [(ngModel)]="searchTerm"
-              (input)="applyFilter()"
-            />
-            <div class="input-group-append">
-              <span class="input-group-text">
-                <fa-icon [icon]="faSearch"></fa-icon>
-              </span>
-            </div>
-          </div>
-        </div>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -65,10 +65,7 @@
         class="csc-projects"
         *ngIf="!dataLoading && filteredCscProjectsList.length > 0"
       >
-        <p>
-          <strong>Total projects:</strong>
-          {{ getFilteredProjectsCount() }}
-        </p>
+        <p>Showing ({{ getFilteredProjectsCount() }}) matching projects.</p>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -13,6 +13,7 @@ import { Location } from "@angular/common";
 import { UrlService } from "../url.service";
 import { MatTableDataSource } from "@angular/material/table";
 import { MatSort, Sort } from "@angular/material/sort";
+import { faSearch } from "@fortawesome/free-solid-svg-icons";
 
 @Component({
   selector: "app-csc",
@@ -24,6 +25,7 @@ export class CscComponent implements OnInit {
   dataSource: MatTableDataSource<any>;
   @ViewChild(MatSort) sort = new MatSort();
 
+  faSearch = faSearch;
   sub: any;
   id: any;
   sbId: any;
@@ -38,6 +40,7 @@ export class CscComponent implements OnInit {
   current_status = ["All Statuses"];
   title = null;
   dataLoading = true;
+  searchTerm = "";
   csc_ids = {
     "5050cb0ee4b0be20bb30eac0": "National CASC",
     "4f831626e4b0e84f6086809b": "Alaska CASC",
@@ -235,6 +238,11 @@ export class CscComponent implements OnInit {
     return this.filteredCscProjectsList.length;
   }
 
+  applyFilter() {
+    // This works in conjunction with the sidebar filters to filter the table
+    this.dataSource.filter = this.searchTerm.trim().toLowerCase();
+  }
+
   ngOnInit() {
     this.sub = this.route.params.subscribe((params) => {
       this.id = params["id"];
@@ -323,6 +331,16 @@ export class CscComponent implements OnInit {
       this.dataSource.sort = this.sort;
       // Sets the default sorting to the fiscal year column to show the downward arrow
       this.setInitialSort();
+
+      this.dataSource.filterPredicate = (data, filter) => {
+        return (
+          data.fiscal_year.toString().includes(filter) ||
+          data.title.toLowerCase().includes(filter) ||
+          data.investigators_formatted.toLowerCase().includes(filter) ||
+          data.topics_formatted.toLowerCase().includes(filter) ||
+          data.status.toLowerCase().includes(filter)
+        );
+      };
     });
   }
   setInitialSort() {

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -234,10 +234,6 @@ export class CscComponent implements OnInit {
     this.location.replaceState(url);
   }
 
-  getFilteredProjectsCount() {
-    return this.filteredCscProjectsList.length;
-  }
-
   applyFilter() {
     // This works in conjunction with the sidebar filters to filter the table
     this.dataSource.filter = this.searchTerm.trim().toLowerCase();

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -231,6 +231,10 @@ export class CscComponent implements OnInit {
     this.location.replaceState(url);
   }
 
+  getFilteredProjectsCount() {
+    return this.filteredCscProjectsList.length;
+  }
+
   ngOnInit() {
     this.sub = this.route.params.subscribe((params) => {
       this.id = params["id"];

--- a/src/app/shared.scss
+++ b/src/app/shared.scss
@@ -111,3 +111,33 @@ td.mat-mdc-cell ul {
     font-size: 1.25rem;
   }
 }
+
+.search-bar-div {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding-right: 20px;
+  margin-bottom: 10px;
+}
+
+.search-bar-wrapper {
+  max-width: 300px;
+  width: 100%;
+}
+
+.search-bar {
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  font-size: 16px;
+  padding-right: 2.25rem;
+}
+
+.input-group-append .input-group-text {
+  background-color: #fff;
+  height: 39.5px;
+  border-left: none;
+  border-radius: 0 20px 20px 0;
+  padding: 0.375rem 0.75rem;
+  display: flex;
+  align-items: center;
+}

--- a/src/app/shared.scss
+++ b/src/app/shared.scss
@@ -112,24 +112,18 @@ td.mat-mdc-cell ul {
   }
 }
 
+.inline {
+  display: inline-block;
+}
+
 .search-bar-div {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  padding-right: 20px;
-  margin-bottom: 10px;
+  float: right;
 }
 
 .search-bar-wrapper {
   max-width: 300px;
   width: 100%;
-}
-
-.search-bar {
-  border: 1px solid #ccc;
-  border-radius: 20px;
-  font-size: 16px;
-  padding-right: 2.25rem;
+  margin-bottom: 0 !important;
 }
 
 .input-group-append .input-group-text {

--- a/src/app/shared.scss
+++ b/src/app/shared.scss
@@ -111,27 +111,3 @@ td.mat-mdc-cell ul {
     font-size: 1.25rem;
   }
 }
-
-.inline {
-  display: inline-block;
-}
-
-.search-bar-div {
-  float: right;
-}
-
-.search-bar-wrapper {
-  max-width: 300px;
-  width: 100%;
-  margin-bottom: 0 !important;
-}
-
-.input-group-append .input-group-text {
-  background-color: #fff;
-  height: 39.5px;
-  border-left: none;
-  border-radius: 0 20px 20px 0;
-  padding: 0.375rem 0.75rem;
-  display: flex;
-  align-items: center;
-}

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -68,6 +68,27 @@
     </div>
 
     <div class="col-md-10 results-table">
+      <!-- These sit outside of the divs because we want the search bar to still 
+           appear when we have no results shown so that we can remove the text in
+           the search bar to update the results.
+      -->
+      <p
+        *ngIf="!dataLoading && dataSource.filteredData.length > 0"
+        class="inline"
+      >
+        Showing ({{ dataSource.filteredData.length }}) matching projects.
+      </p>
+      <div *ngIf="!dataLoading" class="search-bar-div inline">
+        <div class="input-group mb-3 search-bar-wrapper">
+          <input
+            class="form-control search-bar"
+            type="text"
+            placeholder="Filter by term"
+            [(ngModel)]="searchTerm"
+            (input)="applyFilter()"
+          />
+        </div>
+      </div>
       <div *ngIf="dataLoading">
         <h4 class="loading">
           <img
@@ -79,31 +100,17 @@
         </h4>
       </div>
 
-      <div class="no_data" *ngIf="!dataLoading && dataSource.data.length === 0">
+      <div
+        class="no_data"
+        *ngIf="!dataLoading && dataSource.filteredData.length === 0"
+      >
         <h4 class="no_data">
           No projects match all the search filters selected.
         </h4>
         <p>Remove one or more filters to see matching projects.</p>
       </div>
 
-      <div *ngIf="!dataLoading && dataSource.data.length > 0">
-        <p>Showing ({{ getFilteredProjectsCount() }}) matching projects.</p>
-        <div class="search-bar-div">
-          <div class="input-group mb-3 search-bar-wrapper">
-            <input
-              class="form-control search-bar"
-              type="text"
-              placeholder="Search by term"
-              [(ngModel)]="searchTerm"
-              (input)="applyFilter()"
-            />
-            <div class="input-group-append">
-              <span class="input-group-text">
-                <fa-icon [icon]="faSearch"></fa-icon>
-              </span>
-            </div>
-          </div>
-        </div>
+      <div *ngIf="!dataLoading && dataSource.filteredData.length > 0">
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -91,6 +91,22 @@
 
       <div *ngIf="!dataLoading && filteredProjectsList.length > 0">
         <p>Showing ({{ getFilteredProjectsCount() }}) matching projects.</p>
+        <div class="search-bar-div">
+          <div class="input-group mb-3 search-bar-wrapper">
+            <input
+              class="form-control search-bar"
+              type="text"
+              placeholder="Search by term"
+              [(ngModel)]="searchTerm"
+              (input)="applyFilter()"
+            />
+            <div class="input-group-append">
+              <span class="input-group-text">
+                <fa-icon [icon]="faSearch"></fa-icon>
+              </span>
+            </div>
+          </div>
+        </div>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -68,25 +68,28 @@
     </div>
 
     <div class="col-md-10 results-table">
-      <!-- These sit outside of the divs because we want the search bar to still 
+      <!-- These need to still 
            appear when we have no results shown so that we can remove the text in
            the search bar to update the results.
       -->
-      <p
-        *ngIf="!dataLoading && dataSource.filteredData.length > 0"
-        class="inline"
-      >
-        Showing ({{ dataSource.filteredData.length }}) matching projects.
-      </p>
-      <div *ngIf="!dataLoading" class="search-bar-div inline">
-        <div class="input-group mb-3 search-bar-wrapper">
-          <input
-            class="form-control search-bar"
-            type="text"
-            placeholder="Filter by term"
-            [(ngModel)]="searchTerm"
-            (input)="applyFilter()"
-          />
+      <div class="row pb-3">
+        <div class="col-8">
+          <p *ngIf="!dataLoading && dataSource.filteredData.length > 0">
+            Showing {{ dataSource.filteredData.length }} matching projects.
+          </p>
+        </div>
+        <div class="col-4">
+          <div *ngIf="!dataLoading" class="search-bar-div inline">
+            <div class="search-bar-wrapper">
+              <input
+                class="form-control search-bar"
+                type="text"
+                placeholder="Filter by term"
+                [(ngModel)]="searchTerm"
+                (input)="applyFilter()"
+              />
+            </div>
+          </div>
         </div>
       </div>
       <div *ngIf="dataLoading">

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -90,10 +90,7 @@
       </div>
 
       <div *ngIf="!dataLoading && filteredProjectsList.length > 0">
-        <p>
-          <strong>Total projects:</strong>
-          {{ getFilteredProjectsCount() }}
-        </p>
+        <p>Showing ({{ getFilteredProjectsCount() }}) matching projects.</p>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -79,17 +79,14 @@
         </h4>
       </div>
 
-      <div
-        class="no_data"
-        *ngIf="filteredProjectsList.length === 0 && dataLoading === false"
-      >
+      <div class="no_data" *ngIf="!dataLoading && dataSource.data.length === 0">
         <h4 class="no_data">
           No projects match all the search filters selected.
         </h4>
         <p>Remove one or more filters to see matching projects.</p>
       </div>
 
-      <div *ngIf="!dataLoading && filteredProjectsList.length > 0">
+      <div *ngIf="!dataLoading && dataSource.data.length > 0">
         <p>Showing ({{ getFilteredProjectsCount() }}) matching projects.</p>
         <div class="search-bar-div">
           <div class="input-group mb-3 search-bar-wrapper">

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -90,6 +90,10 @@
       </div>
 
       <div *ngIf="!dataLoading && filteredProjectsList.length > 0">
+        <p>
+          <strong>Total projects:</strong>
+          {{ getFilteredProjectsCount() }}
+        </p>
         <table
           mat-table
           [dataSource]="dataSource"

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -305,10 +305,6 @@ export class TopicsComponent implements OnInit {
     this.location.replaceState(url);
   }
 
-  getFilteredProjectsCount() {
-    return this.filteredProjectsList.length;
-  }
-
   applyFilter() {
     // This works in conjunction with the sidebar filters to filter the table
     this.dataSource.filter = this.searchTerm.trim().toLowerCase();

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -14,6 +14,7 @@ import { Location } from "@angular/common";
 import { UrlService } from "../url.service";
 import { MatTableDataSource } from "@angular/material/table";
 import { MatSort, Sort } from "@angular/material/sort";
+import { faSearch } from "@fortawesome/free-solid-svg-icons";
 
 @Component({
   selector: "app-topics",
@@ -49,6 +50,7 @@ export class TopicsComponent implements OnInit {
   topics_url = environment.baseURL;
   project_url = environment.baseURL + "/project";
 
+  faSearch = faSearch;
   url: any;
   subtopics = [];
   fiscal_years = [];
@@ -64,6 +66,7 @@ export class TopicsComponent implements OnInit {
   projectsList = [];
   filteredProjectsList = [];
   dataLoading = true;
+  searchTerm = "";
 
   subtopicsFilter: string[] = null;
 
@@ -306,6 +309,11 @@ export class TopicsComponent implements OnInit {
     return this.filteredProjectsList.length;
   }
 
+  applyFilter() {
+    // This works in conjunction with the sidebar filters to filter the table
+    this.dataSource.filter = this.searchTerm.trim().toLowerCase();
+  }
+
   ngOnInit() {
     this.sub = this.route.params.subscribe((params) => {
       this.topic = params["topic"];
@@ -432,6 +440,16 @@ export class TopicsComponent implements OnInit {
         this.dataSource.sort = this.sort;
         // Sets the default sorting to the fiscal year column to show the downward arrow
         this.setInitialSort();
+
+        this.dataSource.filterPredicate = (data, filter) => {
+          return (
+            data.fiscal_year.toString().includes(filter) ||
+            data.title.toLowerCase().includes(filter) ||
+            data.csc_name.toLowerCase().includes(filter) ||
+            data.subtopics_formatted.toLowerCase().includes(filter) ||
+            data.status.toLowerCase().includes(filter)
+          );
+        };
       });
   }
   setInitialSort() {

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -302,6 +302,10 @@ export class TopicsComponent implements OnInit {
     this.location.replaceState(url);
   }
 
+  getFilteredProjectsCount() {
+    return this.filteredProjectsList.length;
+  }
+
   ngOnInit() {
     this.sub = this.route.params.subscribe((params) => {
       this.topic = params["topic"];


### PR DESCRIPTION
This PR adds a small search bar at the top right of the topics and CASC pages to allow for the table below to be narrowed by a search term provided. This works in conjunction with the sidebar filtering to really quickly find a project you are looking for. 

Closes #165 