### PR TITLE
Adds unordered list to CASC pages for PIs on the project

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -40,13 +40,8 @@
               "budgets": [
                 {
                   "type": "initial",
-<<<<<<< HEAD
                   "maximumWarning": "500mb",
                   "maximumError": "1000mb"
-=======
-                  "maximumWarning": "2mb",
-                  "maximumError": "4mb"
->>>>>>> 6f5f38d (Better min-max values.)
                 },
                 {
                   "type": "anyComponentStyle",

--- a/angular.json
+++ b/angular.json
@@ -40,8 +40,13 @@
               "budgets": [
                 {
                   "type": "initial",
+<<<<<<< HEAD
                   "maximumWarning": "500mb",
                   "maximumError": "1000mb"
+=======
+                  "maximumWarning": "2mb",
+                  "maximumError": "4mb"
+>>>>>>> 6f5f38d (Better min-max values.)
                 },
                 {
                   "type": "anyComponentStyle",

--- a/src/app/csc/csc.component.scss
+++ b/src/app/csc/csc.component.scss
@@ -9,7 +9,6 @@
   }
 }
 
-// This is so that the last item in the list doesn't have extra padding
-td.mat-mdc-cell ul li:not(:last-child) {
-  padding-bottom: 0.5rem;
+ul {
+  list-style-type: none;
 }

--- a/src/app/csc/csc.component.scss
+++ b/src/app/csc/csc.component.scss
@@ -8,3 +8,8 @@
     bottom: 0.2rem;
   }
 }
+
+// This is so that the last item in the list doesn't have extra padding
+td.mat-mdc-cell ul li:not(:last-child) {
+  padding-bottom: 0.5rem;
+}

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -283,12 +283,13 @@ export class CscComponent implements OnInit {
         if (
           this.cscProjectsList[project].contacts.principal_investigators != null
         ) {
-          this.cscProjectsList[project].investigators_formatted = "";
+          this.cscProjectsList[project].investigators_formatted = "<ul>";
           for (const pi of this.cscProjectsList[project].contacts
             .principal_investigators) {
             this.cscProjectsList[project].investigators_formatted +=
-              pi.name + "&nbsp;<i>(" + pi.organization + "</i>)<br>";
+              "<li>" + pi.name + "<i>(" + pi.organization + "</i>)</li>";
           }
+          this.cscProjectsList[project].investigators_formatted += "</ul>";
         } else {
           this.cscProjectsList[project].investigators_formatted = "N/A";
         }

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -287,7 +287,7 @@ export class CscComponent implements OnInit {
           for (const pi of this.cscProjectsList[project].contacts
             .principal_investigators) {
             this.cscProjectsList[project].investigators_formatted +=
-              "<li>" + pi.name + "<i>(" + pi.organization + "</i>)</li>";
+              "<li>" + pi.name + "<i> (" + pi.organization + "</i>)</li>";
           }
           this.cscProjectsList[project].investigators_formatted += "</ul>";
         } else {

--- a/src/app/shared.scss
+++ b/src/app/shared.scss
@@ -111,3 +111,8 @@ td.mat-mdc-cell ul {
     font-size: 1.25rem;
   }
 }
+
+// This is so that the last item in the list doesn't have extra padding
+td.mat-mdc-cell ul li:not(:last-child) {
+  padding-bottom: 0.5rem;
+}


### PR DESCRIPTION
This PR creates an unordered list of the PIs on a project on the CASC page tables. The list has 0.5rem of spacing between each item but excludes that from the last item in each list since there is already space between the end of the project div and the next project div. 

One commit in here reduces the allowed memory budget in production from 500Mb - 1Gb max, to 2b - 4Mb max. This only impacts building, but our memory budget was extremely high and we should probably have saner values here to ensure we are not packaging something extremely inefficient.

Closes #206 