### PR TITLE
Adds a dropdown menu of CASCs or topics to switch between them

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,5 @@
 import { Component } from "@angular/core";
-import { Router, NavigationEnd, Event } from "@angular/router";
-import { Location } from "@angular/common";
+import { Router, NavigationEnd } from "@angular/router";
 import { UrlService } from "./url.service";
 
 @Component({
@@ -12,12 +11,25 @@ export class AppComponent {
   title = "Sustaining Environmental Capitol Initiative";
 
   currentUrl: string = null;
-  constructor(
-    private urlService: UrlService,
-    public router: Router,
-  ) {
+  constructor(private urlService: UrlService, public router: Router) {
     this.router.events.subscribe((event) => {
       if (event instanceof NavigationEnd) {
+        // Check if the current URL and the event.url both contain /topics or /casc
+        // If they do, then we don't want to set the previous URL. This is required
+        // for when we jump between topics or CASC pages.
+        if (
+          (this.currentUrl &&
+            this.currentUrl.includes("/topics") &&
+            event.url.includes("/topics")) ||
+          (this.currentUrl &&
+            this.currentUrl.includes("/casc") &&
+            event.url.includes("/casc"))
+        ) {
+          this.urlService.setPreviousUrl(null);
+          this.currentUrl = event.url;
+          return;
+        }
+        // Sets previousURL if we are not jumping between topics or CASC pages
         this.urlService.setPreviousUrl(this.currentUrl);
         this.currentUrl = event.url;
       }

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -4,7 +4,11 @@
     <h2>{{ title }} Projects</h2>
     <div>
       Switch to
-      <select [(ngModel)]="selectedCasc" (change)="onCascChange($event)">
+      <select
+        [(ngModel)]="selectedCasc"
+        (click)="onSelectClick()"
+        (change)="onCascChange($event)"
+      >
         <option default disabled value="">a different CASC</option>
         <option *ngFor="let key of filtered_csc_identifiers" [value]="key">
           {{ csc_paths[key] }}

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -1,13 +1,16 @@
 <div class="container-fluid">
   <app-breadcrumb></app-breadcrumb>
-  <h2>
-    CASC:
-    <select [(ngModel)]="id" (change)="onCascChange($event)">
-      <option *ngFor="let key of csc_identifiers" [value]="key">
-        {{ csc_paths[key] }}
-      </option>
-    </select>
-  </h2>
+  <div class="table-title">
+    <h2>{{ title }} Projects</h2>
+    <div>
+      Switch to
+      <select [(ngModel)]="id" (change)="onCascChange($event)">
+        <option *ngFor="let key of csc_identifiers" [value]="key">
+          {{ csc_paths[key] }}
+        </option>
+      </select>
+    </div>
+  </div>
   <div class="row csc">
     <div class="col-md-2">
       <!-- Filter Section -->

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -1,6 +1,13 @@
 <div class="container-fluid">
   <app-breadcrumb></app-breadcrumb>
-  <h2 class="table-title">{{ title }} Projects</h2>
+  <h2>
+    CASC:
+    <select [(ngModel)]="id" (change)="onCascChange($event)">
+      <option *ngFor="let key of csc_identifiers" [value]="key">
+        {{ csc_paths[key] }}
+      </option>
+    </select>
+  </h2>
   <div class="row csc">
     <div class="col-md-2">
       <!-- Filter Section -->

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -9,7 +9,7 @@
         (click)="onSelectClick()"
         (change)="onCascChange($event)"
       >
-        <option default disabled value="">a different CASC</option>
+        <option default disabled value="">Choose a CASC</option>
         <option *ngFor="let key of filtered_csc_identifiers" [value]="key">
           {{ csc_paths[key] }}
         </option>

--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -4,8 +4,9 @@
     <h2>{{ title }} Projects</h2>
     <div>
       Switch to
-      <select [(ngModel)]="id" (change)="onCascChange($event)">
-        <option *ngFor="let key of csc_identifiers" [value]="key">
+      <select [(ngModel)]="selectedCasc" (change)="onCascChange($event)">
+        <option default disabled value="">a different CASC</option>
+        <option *ngFor="let key of filtered_csc_identifiers" [value]="key">
           {{ csc_paths[key] }}
         </option>
       </select>

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -26,6 +26,7 @@ export class CscComponent implements OnInit {
   @ViewChild(MatSort) sort = new MatSort();
 
   faSearch = faSearch;
+  csc = null;
   sub: any;
   id: any;
   sbId: any;
@@ -67,6 +68,21 @@ export class CscComponent implements OnInit {
     midwest: "5e2f3f59e4b0a79317d422af",
   };
 
+  csc_paths = {
+    "national-casc": "National CASC",
+    alaska: "Alaska CASC",
+    "north-central": "North Central CASC",
+    northeast: "Northeast CASC",
+    northwest: "Northwest CASC",
+    "pacific-islands": "Pacific Islands CASC",
+    "south-central": "South Central CASC",
+    southeast: "Southeast CASC",
+    southwest: "Southwest CASC",
+    midwest: "Midwest CASC",
+  };
+
+  csc_identifiers = Object.keys(this.csc_paths);
+
   displayedColumns: string[] = [
     "fiscal_year",
     "title",
@@ -85,6 +101,11 @@ export class CscComponent implements OnInit {
     private cdr: ChangeDetectorRef,
   ) {
     this.dataSource = new MatTableDataSource<any>();
+  }
+
+  onCascChange(event: any) {
+    const selectedCasc = event.target.value;
+    this.router.navigate(["/casc", selectedCasc]);
   }
 
   showAllProjects() {
@@ -251,41 +272,43 @@ export class CscComponent implements OnInit {
       if (params["status"]) {
         this.current_status = params["status"].split("+");
       }
-    });
-    if (this.id.length != 24) {
-      this.sbId = this.csc_english_ids[this.id];
-    } else {
-      this.sbId = this.id;
-    }
 
-    this.title = this.csc_ids[this.sbId];
-    this.urlService.setPreviousTitle(this.title);
-    this.urlService.setCurrentTitle(this.title);
-    this.localJson.loadCscProjects(this.sbId).subscribe((data) => {
-      this.cscProjectsList = data;
-      for (const project in this.cscProjectsList) {
-        for (const topic in this.cscProjectsList[project].topics) {
-          if (
-            this.topics.indexOf(this.cscProjectsList[project].topics[topic]) < 0
-          ) {
-            this.topics.push(this.cscProjectsList[project].topics[topic]);
+      if (this.id.length != 24) {
+        this.sbId = this.csc_english_ids[this.id];
+      } else {
+        this.sbId = this.id;
+      }
+
+      this.title = this.csc_ids[this.sbId];
+      this.urlService.setPreviousTitle(this.title);
+      this.urlService.setCurrentTitle(this.title);
+      this.localJson.loadCscProjects(this.sbId).subscribe((data) => {
+        this.cscProjectsList = data;
+        for (const project in this.cscProjectsList) {
+          for (const topic in this.cscProjectsList[project].topics) {
+            if (
+              this.topics.indexOf(this.cscProjectsList[project].topics[topic]) <
+              0
+            ) {
+              this.topics.push(this.cscProjectsList[project].topics[topic]);
+            }
           }
-        }
-        if (
-          this.fiscal_years.indexOf(this.cscProjectsList[project].fiscal_year) <
-          0
-        ) {
-          this.fiscal_years.push(this.cscProjectsList[project].fiscal_year);
-        }
-        if (this.statuses.indexOf(this.cscProjectsList[project].status) < 0) {
-          this.statuses.push(this.cscProjectsList[project].status);
-        }
+          if (
+            this.fiscal_years.indexOf(
+              this.cscProjectsList[project].fiscal_year,
+            ) < 0
+          ) {
+            this.fiscal_years.push(this.cscProjectsList[project].fiscal_year);
+          }
+          if (this.statuses.indexOf(this.cscProjectsList[project].status) < 0) {
+            this.statuses.push(this.cscProjectsList[project].status);
+          }
 
-        // Sort options
-        this.fiscal_years.sort().reverse();
-        this.topics.sort();
-        this.statuses.sort();
-        this.filteredCscProjectsList.push(this.cscProjectsList[project]);
+          // Sort options
+          this.fiscal_years.sort().reverse();
+          this.topics.sort();
+          this.statuses.sort();
+          this.filteredCscProjectsList.push(this.cscProjectsList[project]);
 
         // Principal investigators
         if (
@@ -302,23 +325,23 @@ export class CscComponent implements OnInit {
           this.cscProjectsList[project].investigators_formatted = "N/A";
         }
 
-        // Topics
-        if (this.cscProjectsList[project].topics != null) {
-          this.cscProjectsList[project].topics_formatted = "<ul>";
-          for (const t of this.cscProjectsList[project].topics) {
-            this.cscProjectsList[project].topics_formatted +=
-              "<li>" + t + "</li>";
+          // Topics
+          if (this.cscProjectsList[project].topics != null) {
+            this.cscProjectsList[project].topics_formatted = "<ul>";
+            for (const t of this.cscProjectsList[project].topics) {
+              this.cscProjectsList[project].topics_formatted +=
+                "<li>" + t + "</li>";
+            }
+            this.cscProjectsList[project].topics_formatted += "</ul>";
+          } else {
+            this.cscProjectsList[project].topics_formatted = "N/A";
           }
-          this.cscProjectsList[project].topics_formatted += "</ul>";
-        } else {
-          this.cscProjectsList[project].topics_formatted = "N/A";
-        }
 
-        // Status
-        if (!this.cscProjectsList[project].status) {
-          this.cscProjectsList[project].status = "N/A";
+          // Status
+          if (!this.cscProjectsList[project].status) {
+            this.cscProjectsList[project].status = "N/A";
+          }
         }
-      }
 
       this.filterProjectsList();
       this.dataLoading = false;

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -105,6 +105,10 @@ export class CscComponent implements OnInit {
     this.dataSource = new MatTableDataSource<any>();
   }
 
+  onSelectClick() {
+    this.selectedCasc = "";
+  }
+
   onCascChange(event: any) {
     this.selectedCasc = event.target.value;
     this.router.navigate(["/casc", this.selectedCasc]);
@@ -359,7 +363,7 @@ export class CscComponent implements OnInit {
         // Waits until the data is loaded to render the table
         this.cdr.detectChanges();
         // Sets the selectedCasc to the default option
-        this.selectedCasc = "";
+        this.selectedCasc = "national-casc";
         // Applies the sorting to the table after it is available in the DOM
         this.dataSource.sort = this.sort;
         // Sets the default sorting to the fiscal year column to show the downward arrow

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -42,9 +42,11 @@ export class CscComponent implements OnInit {
   title = null;
   dataLoading = true;
   searchTerm = "";
+  selectedCasc: any;
   csc_ids = {
     "5050cb0ee4b0be20bb30eac0": "National CASC",
     "4f831626e4b0e84f6086809b": "Alaska CASC",
+    "5e2f3f59e4b0a79317d422af": "Midwest CASC",
     "4f83509de4b0e84f60868124": "North Central CASC",
     "4f8c648de4b0546c0c397b43": "Northeast CASC",
     "4f8c64d2e4b0546c0c397b46": "Northwest CASC",
@@ -52,12 +54,12 @@ export class CscComponent implements OnInit {
     "4f8c652fe4b0546c0c397b4a": "South Central CASC",
     "4f8c6557e4b0546c0c397b4c": "Southeast CASC",
     "4f8c6580e4b0546c0c397b4e": "Southwest CASC",
-    "5e2f3f59e4b0a79317d422af": "Midwest CASC",
   };
 
   csc_english_ids = {
     "national-casc": "5050cb0ee4b0be20bb30eac0",
     alaska: "4f831626e4b0e84f6086809b",
+    midwest: "5e2f3f59e4b0a79317d422af",
     "north-central": "4f83509de4b0e84f60868124",
     northeast: "4f8c648de4b0546c0c397b43",
     northwest: "4f8c64d2e4b0546c0c397b46",
@@ -65,12 +67,12 @@ export class CscComponent implements OnInit {
     "south-central": "4f8c652fe4b0546c0c397b4a",
     southeast: "4f8c6557e4b0546c0c397b4c",
     southwest: "4f8c6580e4b0546c0c397b4e",
-    midwest: "5e2f3f59e4b0a79317d422af",
   };
 
   csc_paths = {
     "national-casc": "National CASC",
     alaska: "Alaska CASC",
+    midwest: "Midwest CASC",
     "north-central": "North Central CASC",
     northeast: "Northeast CASC",
     northwest: "Northwest CASC",
@@ -78,10 +80,10 @@ export class CscComponent implements OnInit {
     "south-central": "South Central CASC",
     southeast: "Southeast CASC",
     southwest: "Southwest CASC",
-    midwest: "Midwest CASC",
   };
 
   csc_identifiers = Object.keys(this.csc_paths);
+  filtered_csc_identifiers = this.csc_identifiers;
 
   displayedColumns: string[] = [
     "fiscal_year",
@@ -104,8 +106,8 @@ export class CscComponent implements OnInit {
   }
 
   onCascChange(event: any) {
-    const selectedCasc = event.target.value;
-    this.router.navigate(["/casc", selectedCasc]);
+    this.selectedCasc = event.target.value;
+    this.router.navigate(["/casc", this.selectedCasc]);
   }
 
   showAllProjects() {
@@ -288,6 +290,9 @@ export class CscComponent implements OnInit {
       this.urlService.setPreviousTitle(this.title);
       this.urlService.setCurrentTitle(this.title);
       this.localJson.loadCscProjects(this.sbId).subscribe((data) => {
+        this.filtered_csc_identifiers = this.csc_identifiers.filter(
+          (key) => this.csc_paths[key] !== this.title,
+        );
         this.cscProjectsList = data;
         for (const project in this.cscProjectsList) {
           for (const topic in this.cscProjectsList[project].topics) {
@@ -315,20 +320,21 @@ export class CscComponent implements OnInit {
           this.statuses.sort();
           this.filteredCscProjectsList.push(this.cscProjectsList[project]);
 
-        // Principal investigators
-        if (
-          this.cscProjectsList[project].contacts.principal_investigators != null
-        ) {
-          this.cscProjectsList[project].investigators_formatted = "<ul>";
-          for (const pi of this.cscProjectsList[project].contacts
-            .principal_investigators) {
-            this.cscProjectsList[project].investigators_formatted +=
-              "<li>" + pi.name + "<i> (" + pi.organization + "</i>)</li>";
+          // Principal investigators
+          if (
+            this.cscProjectsList[project].contacts.principal_investigators !=
+            null
+          ) {
+            this.cscProjectsList[project].investigators_formatted = "<ul>";
+            for (const pi of this.cscProjectsList[project].contacts
+              .principal_investigators) {
+              this.cscProjectsList[project].investigators_formatted +=
+                "<li>" + pi.name + "<i> (" + pi.organization + "</i>)</li>";
+            }
+            this.cscProjectsList[project].investigators_formatted += "</ul>";
+          } else {
+            this.cscProjectsList[project].investigators_formatted = "N/A";
           }
-          this.cscProjectsList[project].investigators_formatted += "</ul>";
-        } else {
-          this.cscProjectsList[project].investigators_formatted = "N/A";
-        }
 
           // Topics
           if (this.cscProjectsList[project].topics != null) {
@@ -348,24 +354,27 @@ export class CscComponent implements OnInit {
           }
         }
 
-      this.filterProjectsList();
-      this.dataLoading = false;
-      // Waits until the data is loaded to render the table
-      this.cdr.detectChanges();
-      // Applies the sorting to the table after it is available in the DOM
-      this.dataSource.sort = this.sort;
-      // Sets the default sorting to the fiscal year column to show the downward arrow
-      this.setInitialSort();
+        this.filterProjectsList();
+        this.dataLoading = false;
+        // Waits until the data is loaded to render the table
+        this.cdr.detectChanges();
+        // Sets the selectedCasc to the default option
+        this.selectedCasc = "";
+        // Applies the sorting to the table after it is available in the DOM
+        this.dataSource.sort = this.sort;
+        // Sets the default sorting to the fiscal year column to show the downward arrow
+        this.setInitialSort();
 
-      this.dataSource.filterPredicate = (data, filter) => {
-        return (
-          data.fiscal_year.toString().includes(filter) ||
-          data.title.toLowerCase().includes(filter) ||
-          data.investigators_formatted.toLowerCase().includes(filter) ||
-          data.topics_formatted.toLowerCase().includes(filter) ||
-          data.status.toLowerCase().includes(filter)
-        );
-      };
+        this.dataSource.filterPredicate = (data, filter) => {
+          return (
+            data.fiscal_year.toString().includes(filter) ||
+            data.title.toLowerCase().includes(filter) ||
+            data.investigators_formatted.toLowerCase().includes(filter) ||
+            data.topics_formatted.toLowerCase().includes(filter) ||
+            data.status.toLowerCase().includes(filter)
+          );
+        };
+      });
     });
   }
   setInitialSort() {

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -262,6 +262,7 @@ export class CscComponent implements OnInit {
 
   ngOnInit() {
     this.sub = this.route.params.subscribe((params) => {
+      this.dataLoading = true;
       this.id = params["id"];
       if (params["topic"]) {
         this.current_topic = params["topic"].split("+");
@@ -278,6 +279,10 @@ export class CscComponent implements OnInit {
       } else {
         this.sbId = this.id;
       }
+
+      this.topics = [];
+      this.fiscal_years = [];
+      this.statuses = [];
 
       this.title = this.csc_ids[this.sbId];
       this.urlService.setPreviousTitle(this.title);

--- a/src/app/shared.scss
+++ b/src/app/shared.scss
@@ -1,4 +1,4 @@
-h2.table-title {
+.table-title {
   margin: 1.5rem 0.75rem 3rem;
 }
 

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -1,15 +1,16 @@
 <div class="container-fluid">
   <app-breadcrumb></app-breadcrumb>
-
-  <h2>
-    Topic:
-    <select [(ngModel)]="topic" (change)="onTopicChange($event)">
-      <option *ngFor="let key of topicKeys" [value]="key">
-        {{ topic_names[key] }}
-      </option>
-    </select>
-  </h2>
-
+  <div class="table-title">
+    <h2 class="table-title">Topic: {{ page_title }}</h2>
+    <div>
+      Switch to
+      <select [(ngModel)]="topic" (change)="onTopicChange($event)">
+        <option *ngFor="let key of topicKeys" [value]="key">
+          {{ topic_names[key] }}
+        </option>
+      </select>
+    </div>
+  </div>
   <div class="row topic">
     <div class="col-md-2">
       <div class="select-box">

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -4,7 +4,11 @@
     <h2>Topic: {{ page_title }}</h2>
     <div>
       Switch to
-      <select [(ngModel)]="selectedTopic" (change)="onTopicChange($event)">
+      <select
+        [(ngModel)]="selectedTopic"
+        (click)="onSelectClick()"
+        (change)="onTopicChange($event)"
+      >
         <option default disabled value="">a different topic</option>
         <option *ngFor="let key of filtered_topic_keys" [value]="key">
           {{ topic_names[key] }}

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -1,7 +1,14 @@
 <div class="container-fluid">
   <app-breadcrumb></app-breadcrumb>
 
-  <h2 class="table-title">Topic: {{ page_title }}</h2>
+  <h2>
+    Topic:
+    <select [(ngModel)]="topic" (change)="onTopicChange($event)">
+      <option *ngFor="let key of topicKeys" [value]="key">
+        {{ topic_names[key] }}
+      </option>
+    </select>
+  </h2>
 
   <div class="row topic">
     <div class="col-md-2">
@@ -99,7 +106,7 @@
             class="loading"
             alt="Loading Results"
             title="Loading Results"
-          />Loading {{ title }} ScienceBase projects&hellip;
+          />Loading {{ topic_names[topic] }} ScienceBase projects&hellip;
         </h4>
       </div>
 

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -1,11 +1,12 @@
 <div class="container-fluid">
   <app-breadcrumb></app-breadcrumb>
   <div class="table-title">
-    <h2 class="table-title">Topic: {{ page_title }}</h2>
+    <h2>Topic: {{ page_title }}</h2>
     <div>
       Switch to
-      <select [(ngModel)]="topic" (change)="onTopicChange($event)">
-        <option *ngFor="let key of topicKeys" [value]="key">
+      <select [(ngModel)]="selectedTopic" (change)="onTopicChange($event)">
+        <option default disabled value="">a different topic</option>
+        <option *ngFor="let key of filtered_topic_keys" [value]="key">
           {{ topic_names[key] }}
         </option>
       </select>

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -9,7 +9,7 @@
         (click)="onSelectClick()"
         (change)="onTopicChange($event)"
       >
-        <option default disabled value="">a different topic</option>
+        <option default disabled value="">Choose a topic</option>
         <option *ngFor="let key of filtered_topic_keys" [value]="key">
           {{ topic_names[key] }}
         </option>

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -63,10 +63,12 @@ export class TopicsComponent implements OnInit {
   current_status = ["All Statuses"];
   current_csc = ["All CASCs"];
   topicKeys = Object.keys(this.topics);
+  filtered_topic_keys = [];
   projectsList = [];
   filteredProjectsList = [];
   dataLoading = true;
   searchTerm = "";
+  selectedTopic: any;
 
   subtopicsFilter: string[] = null;
 
@@ -92,9 +94,9 @@ export class TopicsComponent implements OnInit {
   ];
 
   onTopicChange(event: any) {
-    const selectedTopic = event.target.value;
+    this.selectedTopic = event.target.value;
 
-    this.router.navigate(["/topics", selectedTopic]);
+    this.router.navigate(["/topics", this.selectedTopic]);
   }
 
   changeCurrentCASC(event: any = null) {
@@ -347,6 +349,9 @@ export class TopicsComponent implements OnInit {
       this.localJson
         .loadTopic(encodeURIComponent(this.topic_names[this.topic]))
         .subscribe((data) => {
+          this.filtered_topic_keys = this.topicKeys.filter(
+            (key) => this.topic_names[key] !== this.topic,
+          );
           this.projectsList = data;
           for (const project in this.projectsList) {
             for (const subtopic in this.projectsList[project].topics) {
@@ -424,26 +429,29 @@ export class TopicsComponent implements OnInit {
             }
           }
 
-        this.current_type = "Project";
-        this.filterProjectsList();
-        this.dataLoading = false;
-        // Waits until the data is loaded to render the table
-        this.cdr.detectChanges();
-        // Applies the sorting to the table after it is available in the DOM
-        this.dataSource.sort = this.sort;
-        // Sets the default sorting to the fiscal year column to show the downward arrow
-        this.setInitialSort();
+          this.current_type = "Project";
+          this.filterProjectsList();
+          this.dataLoading = false;
+          // Waits until the data is loaded to render the table
+          this.cdr.detectChanges();
+          // Sets selectedTopic to default
+          this.selectedTopic = "";
+          // Applies the sorting to the table after it is available in the DOM
+          this.dataSource.sort = this.sort;
+          // Sets the default sorting to the fiscal year column to show the downward arrow
+          this.setInitialSort();
 
-        this.dataSource.filterPredicate = (data, filter) => {
-          return (
-            data.fiscal_year.toString().includes(filter) ||
-            data.title.toLowerCase().includes(filter) ||
-            data.csc_name.toLowerCase().includes(filter) ||
-            data.subtopics_formatted.toLowerCase().includes(filter) ||
-            data.status.toLowerCase().includes(filter)
-          );
-        };
-      });
+          this.dataSource.filterPredicate = (data, filter) => {
+            return (
+              data.fiscal_year.toString().includes(filter) ||
+              data.title.toLowerCase().includes(filter) ||
+              data.csc_name.toLowerCase().includes(filter) ||
+              data.subtopics_formatted.toLowerCase().includes(filter) ||
+              data.status.toLowerCase().includes(filter)
+            );
+          };
+        });
+    });
   }
 
   setInitialSort() {

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -32,16 +32,16 @@ export class TopicsComponent implements OnInit {
 
   topics = {
     "drought-fire-extremes": "588244b0e4b0b3d9add24391",
-    "science-tools": "5b6212e7e4b03f4cf7599b82",
     landscapes: "5882456be4b0b3d9add24395",
+    "science-tools": "5b6212e7e4b03f4cf7599b82",
     "indigenous-peoples": "588246dae4b0b3d9add243a1",
     "water-coasts-ice": "5882464ce4b0b3d9add2439a",
     "wildlife-plants": "58824220e4b0b3d9add2438b",
   };
   topic_names = {
     "drought-fire-extremes": "Drought, Fire and Extreme Weather",
-    "science-tools": "Science Tools for Managers",
     landscapes: "Landscapes",
+    "science-tools": "Science Tools for Managers",
     "indigenous-peoples": "Indigenous Peoples",
     "water-coasts-ice": "Water, Coasts and Ice",
     "wildlife-plants": "Wildlife and Plants",
@@ -92,6 +92,11 @@ export class TopicsComponent implements OnInit {
     "subtopics_formatted",
     "status",
   ];
+
+  onSelectClick() {
+    // Sets the selectedTopic to an empty string to use the default value when select is clicked
+    this.selectedTopic = "";
+  }
 
   onTopicChange(event: any) {
     this.selectedTopic = event.target.value;
@@ -350,7 +355,7 @@ export class TopicsComponent implements OnInit {
         .loadTopic(encodeURIComponent(this.topic_names[this.topic]))
         .subscribe((data) => {
           this.filtered_topic_keys = this.topicKeys.filter(
-            (key) => this.topic_names[key] !== this.topic,
+            (key) => this.topic_names[key] !== this.page_title,
           );
           this.projectsList = data;
           for (const project in this.projectsList) {
@@ -435,7 +440,7 @@ export class TopicsComponent implements OnInit {
           // Waits until the data is loaded to render the table
           this.cdr.detectChanges();
           // Sets selectedTopic to default
-          this.selectedTopic = "";
+          this.selectedTopic = "drought-fire-extremes";
           // Applies the sorting to the table after it is available in the DOM
           this.dataSource.sort = this.sort;
           // Sets the default sorting to the fiscal year column to show the downward arrow


### PR DESCRIPTION
This PR adds a dropdown choice on each of the topic and CASC pages to switch between the topics or CASCs. 

Holly liked this functionality but we probably want to clean it up with a little bit of design changes.

Closes #166 