### PR TITLE
Moves shared CSS into shared.scss file for .loading

### DIFF
--- a/src/app/csc/csc.component.scss
+++ b/src/app/csc/csc.component.scss
@@ -1,14 +1,3 @@
-.loading {
-  img {
-    display: inline-block;
-    height: 2rem;
-    padding-right: 1rem;
-    vertical-align: middle;
-    position: relative;
-    bottom: 0.2rem;
-  }
-}
-
 ul {
   list-style-type: none;
 }

--- a/src/app/search/search.component.scss
+++ b/src/app/search/search.component.scss
@@ -14,17 +14,6 @@
   }
 }
 
-.loading {
-  img {
-    display: inline-block;
-    height: 2rem;
-    padding-right: 1rem;
-    vertical-align: middle;
-    position: relative;
-    bottom: 0.2rem;
-  }
-}
-
 .badges {
   color: white;
   margin-bottom: 1rem;

--- a/src/app/shared.scss
+++ b/src/app/shared.scss
@@ -116,3 +116,14 @@ td.mat-mdc-cell ul {
 td.mat-mdc-cell ul li:not(:last-child) {
   padding-bottom: 0.5rem;
 }
+
+.loading {
+  img {
+    display: inline-block;
+    height: 2rem;
+    padding-right: 1rem;
+    vertical-align: middle;
+    position: relative;
+    bottom: 0.2rem;
+  }
+}

--- a/src/app/topics/topics.component.scss
+++ b/src/app/topics/topics.component.scss
@@ -6,14 +6,3 @@ label {
   position: relative;
   bottom: 1px;
 }
-
-.loading {
-  img {
-    display: inline-block;
-    height: 2rem;
-    padding-right: 1rem;
-    vertical-align: middle;
-    position: relative;
-    bottom: 0.2rem;
-  }
-}


### PR DESCRIPTION
This PR simply moves a shared piece of CSS for the loading icon on multiple pages into the shared.scss location to reduce CSS replication.

Closes #212 