### PR TITLE
Updates checkboxes in topics and CASCs to match the live site

### DIFF
--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -23,7 +23,6 @@
         <h3 class="select-title">Topic</h3>
         <div *ngFor="let topic of topics">
           <mat-checkbox
-            class="casc-checkbox"
             (change)="changeCurrentTopic($event)"
             [checked]="current_topic.indexOf(topic) !== -1"
             [value]="topic"

--- a/src/app/shared.scss
+++ b/src/app/shared.scss
@@ -12,30 +12,31 @@
   }
 
   .mat-mdc-checkbox {
-    display: flex;
-    margin: 0 0 0.2rem;
+    display: inline-block;
     margin-left: -10px;
     font-weight: 400;
     font-family: Lora, serif;
     font-size: 18px;
     margin-right: 1rem;
+    width: 100%;
     vertical-align: top;
 
     .mat-internal-form-field {
       align-items: flex-start;
+      width: 100%;
     }
     .mdc-label {
-      padding-left: 5px;
+      padding-left: 2px;
       font-family: Lora, serif;
       font-weight: 500;
       line-height: 1.4;
-      width: 170px;
+      width: 100%;
       margin-bottom: 0;
     }
 
     .mdc-checkbox {
       width: 15px;
-      height: 15px;
+      height: 13px;
       margin-right: -13px;
       margin-top: -5px;
     }

--- a/src/app/shared.scss
+++ b/src/app/shared.scss
@@ -29,9 +29,9 @@
       padding-left: 2px;
       font-family: Lora, serif;
       font-weight: 500;
-      line-height: 1.4;
+      line-height: 1.3;
       width: 100%;
-      margin-bottom: 0;
+      margin-bottom: 0.25rem;
     }
 
     .mdc-checkbox {

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -28,6 +28,7 @@
             [value]="csc"
             [id]="csc"
             name="csc"
+            class="topic-checkbox"
           >
             {{ csc.replace(" CASC", "") }}</mat-checkbox
           >
@@ -43,6 +44,7 @@
             [value]="subtopic"
             [id]="subtopic"
             name="subtopic"
+            class="topic-checkbox"
           >
             {{ subtopic }}</mat-checkbox
           >
@@ -58,6 +60,7 @@
             [value]="status"
             [id]="status"
             name="status"
+            class="topic-checkbox"
           >
             {{ status }}</mat-checkbox
           >
@@ -73,6 +76,7 @@
             [value]="fy"
             [id]="fy"
             name="fy"
+            class="topic-checkbox"
           >
             {{ fy }}</mat-checkbox
           >

--- a/src/app/topics/topics.component.scss
+++ b/src/app/topics/topics.component.scss
@@ -6,3 +6,7 @@ label {
   position: relative;
   bottom: 1px;
 }
+
+.topic-checkbox {
+  height: 28.5px;
+}


### PR DESCRIPTION
This PR updates the CSS to have the checkboxes and labels be the same between the live site at https://cascprojects.org and the development site at http://localhost:4200.

To test, look at the checkboxes and labels in the following site locations:

**CASCs**
https://cascprojects.org/#/casc/alaska
http://localhost:4200/#/casc/alaska

**Topics**
https://cascprojects.org/#/topics/drought-fire-extremes;type=Project
http://localhost:4200/#/topics/drought-fire-extremes;type=Project

Open two browser windows at the same size and confirm that the checkboxes on the left side of both pages look identical. 

Closes #219 