### PR TITLE
Updates advanced search spinner to match the CSS styling for the rest of the site

### DIFF
--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -3,7 +3,7 @@
     <app-search-nav></app-search-nav>
   </div>
   <div class="col-md-9 results">
-    <div class="loading" *ngIf="total_results === -1">
+    <div *ngIf="total_results === -1">
       <h4 class="loading">
         <img
           src="{{ approot }}assets/loading.gif"
@@ -11,7 +11,7 @@
           alt="Loading Results"
           title="Loading Results"
         />
-        Loading {{ title }} ScienceBase Projects.
+        Loading {{ title }} ScienceBase Projects&hellip;
       </h4>
     </div>
     <div

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -11,7 +11,7 @@
           alt="Loading Results"
           title="Loading Results"
         />
-        Loading {{ title }} ScienceBase Projects&hellip;
+        Searching ScienceBase for matching projects&hellip;
       </h4>
     </div>
     <div

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -9,7 +9,7 @@ import { environment } from "../../environments/environment";
 @Component({
   selector: "app-search",
   templateUrl: "./search.component.html",
-  styleUrls: ["./search.component.scss"],
+  styleUrls: ["./search.component.scss", "../shared.scss"],
 })
 export class SearchComponent implements OnInit, OnDestroy {
   results = [];


### PR DESCRIPTION
This PR fixes the missing CSS that was rendering the advanced search spinner with different styling than the rest of the site. 

The reason why the CSS wasn't being rendered properly is because the shared.scss hadn't been imported into the component.

Closes #224 