### PR TITLE
Clears filters when switching between Topics and CASCs

### DIFF
--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -105,12 +105,22 @@ export class CscComponent implements OnInit {
     this.dataSource = new MatTableDataSource<any>();
   }
 
+  clearFilters() {
+    this.current_topic = ["All Topics"];
+    this.current_fy = ["All Fiscal Years"];
+    this.current_status = ["All Statuses"];
+    this.searchTerm = "";
+    this.applyFilter();
+    this.filterProjectsList();
+  }
+
   onSelectClick() {
     this.selectedCasc = "";
   }
 
   onCascChange(event: any) {
     this.selectedCasc = event.target.value;
+    this.clearFilters();
     this.router.navigate(["/casc", this.selectedCasc]);
   }
 

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -28,7 +28,6 @@
             [value]="csc"
             [id]="csc"
             name="csc"
-            class="topic-checkbox"
           >
             {{ csc.replace(" CASC", "") }}</mat-checkbox
           >
@@ -44,7 +43,6 @@
             [value]="subtopic"
             [id]="subtopic"
             name="subtopic"
-            class="topic-checkbox"
           >
             {{ subtopic }}</mat-checkbox
           >
@@ -60,7 +58,6 @@
             [value]="status"
             [id]="status"
             name="status"
-            class="topic-checkbox"
           >
             {{ status }}</mat-checkbox
           >
@@ -76,7 +73,6 @@
             [value]="fy"
             [id]="fy"
             name="fy"
-            class="topic-checkbox"
           >
             {{ fy }}</mat-checkbox
           >

--- a/src/app/topics/topics.component.scss
+++ b/src/app/topics/topics.component.scss
@@ -1,12 +1,4 @@
-label {
-  padding-left: 0.25rem;
-}
-
 .select-box input[type="checkbox"] {
   position: relative;
   bottom: 1px;
-}
-
-.topic-checkbox {
-  height: 28.5px;
 }

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -391,6 +391,9 @@ export class TopicsComponent implements OnInit {
                 }
               }
             }
+            this.subtopics.sort();
+            this.fiscal_years.sort().reverse();
+            this.statuses.sort();
 
             this.filteredProjectsList.push(this.projectsList[project]);
 

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -93,6 +93,17 @@ export class TopicsComponent implements OnInit {
     "status",
   ];
 
+  clearFilters() {
+    this.current_subtopic = ["All Subtopics"];
+    this.current_fy = ["All Fiscal Years"];
+    this.current_status = ["All Statuses"];
+    this.current_type = "Project";
+    this.current_csc = ["All CASCs"];
+    this.searchTerm = "";
+    this.applyFilter();
+    this.filterProjectsList();
+  }
+
   onSelectClick() {
     // Sets the selectedTopic to an empty string to use the default value when select is clicked
     this.selectedTopic = "";
@@ -100,7 +111,7 @@ export class TopicsComponent implements OnInit {
 
   onTopicChange(event: any) {
     this.selectedTopic = event.target.value;
-
+    this.clearFilters();
     this.router.navigate(["/topics", this.selectedTopic]);
   }
 


### PR DESCRIPTION
This PR is to fix a bug that was identified that wouldn't clear the URL of erroneous entries when switching between topics or CASCs via the dropdown selector. Additionally, the search term that was selected would also carry over to the new topic or CASC, resulting in dramatically lowered search results but not showing the search term any longer.

Now, the search filters are all cleared as part of the process of switching to another topic or CASC, so that we start on a fresh page where the search filters available can be selected again if desired.