### PR TITLE
Updates default CASC and topic to the text in the default value.

### DIFF
--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -363,7 +363,7 @@ export class CscComponent implements OnInit {
         // Waits until the data is loaded to render the table
         this.cdr.detectChanges();
         // Sets the selectedCasc to the default option
-        this.selectedCasc = "national-casc";
+        this.selectedCasc = "";
         // Applies the sorting to the table after it is available in the DOM
         this.dataSource.sort = this.sort;
         // Sets the default sorting to the fiscal year column to show the downward arrow

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -94,7 +94,6 @@ export class TopicsComponent implements OnInit {
   ];
 
   onSelectClick() {
-    // Sets the selectedTopic to an empty string to use the default value when select is clicked
     this.selectedTopic = "";
   }
 
@@ -415,7 +414,7 @@ export class TopicsComponent implements OnInit {
           // Waits until the data is loaded to render the table
           this.cdr.detectChanges();
           // Sets selectedTopic to default
-          this.selectedTopic = "drought-fire-extremes";
+          this.selectedTopic = "";
           // Applies the sorting to the table after it is available in the DOM
           this.dataSource.sort = this.sort;
           // Sets the default sorting to the fiscal year column to show the downward arrow


### PR DESCRIPTION
This PR sets the default CASC and topic to "Choose a CASC" and "Choose a topic" when first loading the page or when switching between the various CASCs or topics.

Resolves a request by Sarah to have this be the default value shown.