### PR TITLE
Search bar fixes for topics and CASC

### DIFF
--- a/src/app/csc/csc.component.html
+++ b/src/app/csc/csc.component.html
@@ -162,9 +162,9 @@
     <!-- Alternative card-based display for mobile -->
     <div
       class="d-lg-none col-xs-10"
-      *ngIf="!dataLoading && filteredCscProjectsList.length > 0"
+      *ngIf="!dataLoading && dataSource.filteredData.length > 0"
     >
-      <div class="card" *ngFor="let project of filteredCscProjectsList">
+      <div class="card" *ngFor="let project of dataSource.filteredData">
         <!--Card content-->
         <div class="card-block mobile">
           <!--Title-->

--- a/src/app/csc/csc.component.ts
+++ b/src/app/csc/csc.component.ts
@@ -100,7 +100,7 @@ export class CscComponent implements OnInit {
     private location: Location,
     private aroute: ActivatedRoute,
     private urlService: UrlService,
-    private cdr: ChangeDetectorRef,
+    private cdr: ChangeDetectorRef
   ) {
     this.dataSource = new MatTableDataSource<any>();
   }
@@ -305,7 +305,7 @@ export class CscComponent implements OnInit {
       this.urlService.setCurrentTitle(this.title);
       this.localJson.loadCscProjects(this.sbId).subscribe((data) => {
         this.filtered_csc_identifiers = this.csc_identifiers.filter(
-          (key) => this.csc_paths[key] !== this.title,
+          (key) => this.csc_paths[key] !== this.title
         );
         this.cscProjectsList = data;
         for (const project in this.cscProjectsList) {
@@ -317,9 +317,12 @@ export class CscComponent implements OnInit {
               this.topics.push(this.cscProjectsList[project].topics[topic]);
             }
           }
+          if (this.cscProjectsList[project].fiscal_year == null) {
+            this.cscProjectsList[project].fiscal_year = "N/A";
+          }
           if (
             this.fiscal_years.indexOf(
-              this.cscProjectsList[project].fiscal_year,
+              this.cscProjectsList[project].fiscal_year
             ) < 0
           ) {
             this.fiscal_years.push(this.cscProjectsList[project].fiscal_year);

--- a/src/app/topics/topics.component.html
+++ b/src/app/topics/topics.component.html
@@ -186,7 +186,7 @@
     </div>
     <!-- Mobile -->
     <div class="d-lg-none col-xs-10">
-      <div class="card" *ngFor="let project of filteredProjectsList">
+      <div class="card" *ngFor="let project of dataSource.filteredData">
         <!--Card content-->
         <div class="card-block mobile">
           <!--Title-->

--- a/src/app/topics/topics.component.ts
+++ b/src/app/topics/topics.component.ts
@@ -80,7 +80,7 @@ export class TopicsComponent implements OnInit {
     private location: Location,
     private aroute: ActivatedRoute,
     private urlService: UrlService,
-    private cdr: ChangeDetectorRef,
+    private cdr: ChangeDetectorRef
   ) {
     this.dataSource = new MatTableDataSource<any>();
   }
@@ -202,7 +202,7 @@ export class TopicsComponent implements OnInit {
         !this.isMatched(
           project.subtopics || [],
           this.current_subtopic,
-          "All Subtopics",
+          "All Subtopics"
         )
       )
         continue;
@@ -214,7 +214,7 @@ export class TopicsComponent implements OnInit {
         !this.isMatched(
           [project.fiscal_year],
           this.current_fy,
-          "All Fiscal Years",
+          "All Fiscal Years"
         )
       )
         continue;
@@ -226,7 +226,7 @@ export class TopicsComponent implements OnInit {
         !this.isMatched(
           [project.csc?.name || ""],
           this.current_csc,
-          "All CASCs",
+          "All CASCs"
         )
       )
         continue;
@@ -340,7 +340,7 @@ export class TopicsComponent implements OnInit {
         .loadTopic(encodeURIComponent(this.topic_names[this.topic]))
         .subscribe((data) => {
           this.filtered_topic_keys = this.topicKeys.filter(
-            (key) => this.topic_names[key] !== this.page_title,
+            (key) => this.topic_names[key] !== this.page_title
           );
           this.projectsList = data;
           for (const project in this.projectsList) {
@@ -351,19 +351,22 @@ export class TopicsComponent implements OnInit {
                     this.projectsList[project].subtopics[subtopic] ==
                       this.subtopicsFilter[topicSubtopic]["label"] &&
                     this.subtopics.indexOf(
-                      this.projectsList[project].subtopics[subtopic],
+                      this.projectsList[project].subtopics[subtopic]
                     ) < 0
                   ) {
                     this.subtopics.push(
-                      this.projectsList[project].subtopics[subtopic],
+                      this.projectsList[project].subtopics[subtopic]
                     );
                   }
                 }
               }
             }
+            if (this.projectsList[project].fiscal_year == null) {
+              this.projectsList[project].fiscal_year = "N/A";
+            }
             if (
               this.fiscal_years.indexOf(
-                this.projectsList[project].fiscal_year,
+                this.projectsList[project].fiscal_year
               ) < 0
             ) {
               if (this.projectsList[project].fiscal_year != null) {


### PR DESCRIPTION
This PR fixes the search bar for both topics and CASCs across all of the various topics and CASCs. The issue came down to the filterPredicate function that configures how the MatTable is filtered was having errors when the fiscal year field was set to 'null' which happens when that field is left out in a ScienceBase article. If the field is set to 'null', it is now simply set to "N/A".

Additionally, this fixes a bug identified in the mobile view of the application that was not collecting the correct data to populate the card views. 

For testing, you should go to the CASCs listed in #228 and make sure that the mobile view matches the table view of the application as well. This also changes the topic pages, so ensuring the table updates dynamically with the search term.

Closes #228 