### PR TITLE
Adds environment variable to determine if the site is slow banner needs to be shown.

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -12,3 +12,16 @@
     </div>
   </div>
 </div>
+
+<div class="container-alert">
+  <div class="alert alert-warning" role="alert">
+    <p>
+      CASC Project Explorer is experiencing lengthy load times, please
+      <a
+        href="https://www.usgs.gov/programs/climate-adaptation-science-centers/science"
+        >go here</a
+      >
+      for more project details.
+    </p>
+  </div>
+</div>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -13,7 +13,7 @@
   </div>
 </div>
 
-<div class="container-alert">
+<div class="container-alert" *ngIf="showSiteSlowAlert">
   <div class="alert alert-warning" role="alert">
     <p>
       CASC Project Explorer is experiencing lengthy load times, please

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -1,3 +1,13 @@
+.container-alert {
+  width: 100%;
+  text-align: center;
+  padding: 0;
+
+  p {
+    margin: 0;
+  }
+}
+
 .headerTop {
   background-color: rgb(0, 38, 76);
   color: #fff;

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,8 +1,11 @@
 import { Component } from "@angular/core";
+import { environment } from "../../environments/environment";
 
 @Component({
   selector: "app-header",
   templateUrl: "./header.component.html",
   styleUrls: ["./header.component.scss"],
 })
-export class HeaderComponent {}
+export class HeaderComponent {
+  showSiteSlowAlert = environment.siteSlow;
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -6,4 +6,5 @@ export const environment = {
   sbmainURL: "https://www.sciencebase.gov",
   projectsPath: "/projects/#",
   urlPrefix: "/",
+  siteSlow: false, // Set to true to show the slow site alert
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -11,4 +11,5 @@ export const environment = {
   sbmainURL: "https://www.sciencebase.gov",
   projectsPath: "/projects/#",
   urlPrefix: "/casc/",
+  siteSlow: false, // Set to true to show the slow site alert
 };


### PR DESCRIPTION
This PR adds the environment variable "siteSlow" to the environment files contained within this project. If we want the banner to be shown, we need only open up the app/environments/environment.ts file and change siteSlow to true. The same is true of the environment.prod.ts file if we want this change to show up in a production build. 

This is set to false by default so that the slow banner won't show up unless we intentionally add it.